### PR TITLE
Fix SSR blank renders and DB selection

### DIFF
--- a/src/app/api/search-posts/route.ts
+++ b/src/app/api/search-posts/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { clientPromise } from "../../../lib/mongo";
+import { getMongoDb } from "../../../lib/mongo";
 
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
     const query = searchParams.get("query") || "";
 
-    const client = await clientPromise;
-    const db = client.db("blog");
+    const db = await getMongoDb();
     const postsCollection = db.collection("posts");
 
     // Busca posts com projeção para retornar apenas os campos necessários

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,9 +122,6 @@ export default function Home() {
     setShowDeleteModal(false);
     setPostToDelete(null);
   };
-
-  if (typeof window === "undefined") return null;
-
   return (
     <>
       <NextSeo

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -89,9 +89,6 @@ export default function Post({ params }: PostParams) {
   const { date, title, htmlContent, views, audioUrl, cape, friendImage } = postData;
   const path = `/posts/${id}`;
   const readingTime = calculateReadingTime(htmlContent);
-
-  if (typeof window === "undefined") return null;
-
   return (
     <>
       <NextSeo


### PR DESCRIPTION
## Summary
- allow the home and post pages to render during SSR by removing `window` guards
- reuse the shared MongoDB helper in the search API route so the configured database name is honored

## Testing
- `npm run build` *(fails: The OPENAI_API_KEY environment variable is missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_68f83b7985b8832297e67455d1dce673