### PR TITLE
Prevent home prerender router context error

### DIFF
--- a/src/app/api/search-posts/route.ts
+++ b/src/app/api/search-posts/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { clientPromise } from "../../../lib/mongo";
+import { getMongoDb } from "../../../lib/mongo";
 
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
     const query = searchParams.get("query") || "";
 
-    const client = await clientPromise;
-    const db = client.db("blog");
+    const db = await getMongoDb();
     const postsCollection = db.collection("posts");
 
     // Busca posts com projeção para retornar apenas os campos necessários

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import { NextSeo } from "next-seo";
 import { Date } from "@components/date";
 import { Layout } from "@components/layout";
@@ -20,7 +19,6 @@ type PostData = {
 };
 
 export default function Home() {
-  const router = useRouter();
   const [posts, setPosts] = useState<PostData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -88,11 +86,6 @@ export default function Home() {
     checkAdminStatus();
   }, []);
 
-  const handlePostClick = (postId: string, e: React.MouseEvent) => {
-    e.preventDefault();
-    router.push(`/posts/${postId}`);
-  };
-
   const handleDeletePost = async (postId: string) => {
     try {
       const response = await fetch("/staff/deletePost", {
@@ -122,9 +115,6 @@ export default function Home() {
     setShowDeleteModal(false);
     setPostToDelete(null);
   };
-
-  if (typeof window === "undefined") return null;
-
   return (
     <>
       <NextSeo
@@ -173,7 +163,6 @@ export default function Home() {
                 >
                     <Link
                       href={`/posts/${post.postId}`}
-                      onClick={(e) => handlePostClick(post.postId, e)}
                       className="text-xl hover:underline"
                     >
                       {post.title}

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -89,9 +89,6 @@ export default function Post({ params }: PostParams) {
   const { date, title, htmlContent, views, audioUrl, cape, friendImage } = postData;
   const path = `/posts/${id}`;
   const readingTime = calculateReadingTime(htmlContent);
-
-  if (typeof window === "undefined") return null;
-
   return (
     <>
       <NextSeo


### PR DESCRIPTION
## Summary
- stop using the imperative router push on the home listing so prerendering no longer touches the App Router context

## Testing
- `OPENAI_API_KEY=dummy npm run build` *(fails: Defina MONGODB_URI e MONGODB_DB no .env.local)*

------
https://chatgpt.com/codex/tasks/task_e_68f83b7985b8832297e67455d1dce673