### PR TITLE
Align spacing with Tailwind scale

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -55,8 +55,8 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
   };
 
   return (
-    <div className="w-full max-w-2xl mx-auto rounded-lg shadow-md flex 
-                    items-center gap-3">
+    <div className="w-full max-w-2xl mx-auto rounded-lg shadow-md flex
+                    items-center gap-4">
       {/* Elemento de áudio oculto para controle */}
       <audio
         ref={audioRef}
@@ -69,7 +69,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
       {/* Botão de play/pause */}
       <button
         onClick={togglePlayPause}
-        className="text-zinc-400 hover:text-zinc-300 rounded p-0.5"
+        className="text-zinc-400 hover:text-zinc-300 rounded p-2"
         aria-label={isPlaying ? "Pausar" : "Tocar"}
       >
         {isPlaying ? (

--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -458,9 +458,9 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
 
         <form
           onSubmit={handleCommentSubmit}
-          className="space-y-4 rounded-3xl border border-zinc-800/80 bg-zinc-950/70 p-3 sm:p-4 md:p-5 shadow-inner shadow-black/40"
+          className="space-y-6 rounded-3xl border border-zinc-800/80 bg-zinc-950/70 p-4 sm:p-6 md:p-8 shadow-inner shadow-black/40"
         >
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
             {!userId && (
               <div className="space-y-2">
                 <input
@@ -469,7 +469,7 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
                   placeholder="Digite seu nome"
                   value={commentDraft.nome}
                   onChange={(event) => handleCommentDraftChange("nome", event.target.value)}
-                  className="w-full rounded-2xl border border-zinc-800/70 bg-zinc-900/70 px-3 py-2 sm:px-4 sm:py-2.5 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
+                  className="w-full rounded-2xl border border-zinc-800/70 bg-zinc-900/70 px-4 py-2 sm:px-6 sm:py-4 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
                   disabled={submissionStatus === "sending"}
                 />
                 <p className="text-xs text-zinc-500">Esse nome aparecerá junto ao seu comentário.</p>
@@ -481,12 +481,12 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
               placeholder="Escreva seu comentário"
               value={commentDraft.comentario}
               onChange={(event) => handleCommentDraftChange("comentario", event.target.value)}
-              className="h-20 sm:h-24 w-full resize-none rounded-2xl border border-zinc-800/70 bg-zinc-900/70 px-3 py-2 sm:px-4 sm:py-2.5 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
+              className="h-20 sm:h-24 w-full resize-none rounded-2xl border border-zinc-800/70 bg-zinc-900/70 px-4 py-2 sm:px-6 sm:py-4 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
               disabled={submissionStatus === "sending"}
             />
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+          <div className="flex flex-wrap items-center justify-between gap-4 text-sm">
             <div className="text-xs text-zinc-500">
               {commentDraft.comentario.length}/{COMMENT_MAX_LENGTH}
             </div>
@@ -516,7 +516,7 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
           <p className="rounded-2xl border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-300">{errorMessage}</p>
         )}
 
-        <div className="mt-6 space-y-4">
+        <div className="mt-8 space-y-6">
           <CommentThread
             parentId={null}
             lookup={commentLookup}
@@ -535,7 +535,7 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
           />
 
           {totalComments === 0 && (
-            <p className="rounded-2xl border border-zinc-800/80 bg-zinc-950/60 px-3 py-2 sm:px-4 sm:py-2.5 text-sm text-zinc-400">Nenhum comentário ainda. Seja o primeiro!</p>
+            <p className="rounded-2xl border border-zinc-800/80 bg-zinc-950/60 px-4 py-2 sm:px-6 sm:py-4 text-sm text-zinc-400">Nenhum comentário ainda. Seja o primeiro!</p>
           )}
         </div>
       </div>

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -37,7 +37,7 @@ export default function SearchBar({ onSearch, initialQuery = "", rightSlot }: Se
 
   return (
     <form onSubmit={handleSubmit} className="relative">
-      <div className="flex items-center gap-2 bg-zinc-800 border border-zinc-700 rounded px-1 py-0.5 w-[30vw] min-w-[220px] sm:w-1/3 md:w-[360px]">
+      <div className="flex items-center gap-2 bg-zinc-800 border border-zinc-700 rounded px-2 py-1 w-[30vw] min-w-[220px] sm:w-1/3 md:w-[360px]">
         <MagnifyingGlassIcon className="w-4 h-4" />
         <input
           ref={inputRef}

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -68,21 +68,21 @@ const CommentItem: React.FC<CommentItemProps> = ({
 
   return (
     <article
-      className={`rounded-2xl border bg-zinc-950/70 p-2.5 sm:p-3.5 transition-all ${
+      className={`rounded-2xl border bg-zinc-950/70 p-4 sm:p-6 transition-all ${
         comment.optimistic
           ? "border-purple-500/60 shadow-lg shadow-purple-800/30"
           : "border-zinc-800/80"
       }`}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-start gap-4">
         <img
           src={avatarUrl}
           alt={`${displayName} avatar`}
           className="h-8 w-8 rounded-full max-sm:w-6 object-cover icon"
         />
-        <div className="flex-1 space-y-3">
-          <div className="flex flex-wrap items-center gap-2 text-sm">
-            <span className="font-semibold text-zinc-100 flex items-center gap-1">
+        <div className="flex-1 space-y-4">
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <span className="font-semibold text-zinc-100 flex items-center gap-2">
               {displayName}
               {isAuthComment(comment) && (
                 <CheckBadgeIcon
@@ -100,22 +100,22 @@ const CommentItem: React.FC<CommentItemProps> = ({
               {formatDate(comment.createdAt)}
             </span>
             {isAuthComment(comment) && comment.role === "admin" && (
-              <span className="rounded-full border border-yellow-500/40 px-2 py-0.5 text-[10px] uppercase tracking-wide text-yellow-300">
+              <span className="rounded-full border border-yellow-500/40 px-3 py-1 text-[10px] uppercase tracking-wide text-yellow-300">
                 Autor
               </span>
             )}
             {isAuthComment(comment) && comment.role === "moderator" && (
-              <span className="rounded-full border border-red-500/40 px-2 py-0.5 text-[10px] uppercase tracking-wide text-red-300">
+              <span className="rounded-full border border-red-500/40 px-3 py-1 text-[10px] uppercase tracking-wide text-red-300">
                 Colaborador
               </span>
             )}
             {isAuthComment(comment) && coAuthorUserId && comment.userId === coAuthorUserId && (
-              <span className="rounded-full border border-blue-500/40 px-2 py-0.5 text-[10px] tracking-wide text-blue-300">
+              <span className="rounded-full border border-blue-500/40 px-3 py-1 text-[10px] tracking-wide text-blue-300">
                 (co-autor)
               </span>
             )}
             {comment.optimistic && (
-              <span className="rounded-full border border-purple-500/60 px-2 py-0.5 text-[10px] uppercase tracking-wide text-purple-300">
+              <span className="rounded-full border border-purple-500/60 px-3 py-1 text-[10px] uppercase tracking-wide text-purple-300">
                 Enviando...
               </span>
             )}
@@ -128,11 +128,11 @@ const CommentItem: React.FC<CommentItemProps> = ({
             }}
           />
 
-          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+          <div className="flex flex-wrap items-center gap-4 text-xs text-zinc-400">
             <button
               type="button"
               onClick={onReplyRequest}
-              className="rounded-full border border-zinc-700/60 px-3 py-1 font-medium text-zinc-200 transition hover:border-purple-500 hover:text-white"
+              className="rounded-full border border-zinc-700/60 px-4 py-2 font-medium text-zinc-200 transition hover:border-purple-500 hover:text-white"
             >
               Responder
             </button>
@@ -141,7 +141,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
                 <button
                   type="button"
                   onClick={() => setShowDeleteModal(true)}
-                  className="flex items-center gap-1 rounded-full border border-red-500/40 px-3 py-1 font-medium text-red-300 transition hover:border-red-500 hover:text-red-200"
+                  className="flex items-center gap-2 rounded-full border border-red-500/40 px-4 py-2 font-medium text-red-300 transition hover:border-red-500 hover:text-red-200"
                 >
                   <TrashIcon className="h-3.5 w-3.5" /> Remover
                 </button>
@@ -162,11 +162,11 @@ const CommentItem: React.FC<CommentItemProps> = ({
                     >
                       <h3 id={`delete-modal-${comment._id}`} className="text-sm font-semibold text-zinc-100">Confirmar remoção</h3>
                       <p className="mt-2 text-sm text-zinc-400">Tem certeza que deseja remover este comentário? Esta ação não pode ser desfeita.</p>
-                      <div className="mt-4 flex justify-end gap-2">
+                      <div className="mt-4 flex justify-end gap-4">
                         <button
                           type="button"
                           onClick={() => setShowDeleteModal(false)}
-                          className="rounded-full border border-zinc-700/60 px-3 py-1 text-sm text-zinc-200"
+                          className="rounded-full border border-zinc-700/60 px-4 py-2 text-sm text-zinc-200"
                         >
                           Cancelar
                         </button>
@@ -176,7 +176,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
                             setShowDeleteModal(false);
                             onDelete();
                           }}
-                          className="rounded-full bg-red-600 px-4 py-1 text-sm font-semibold text-white hover:bg-red-500"
+                          className="rounded-full bg-red-600 px-5 py-2 text-sm font-semibold text-white hover:bg-red-500"
                         >
                           Remover
                         </button>
@@ -202,7 +202,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
             />
           )}
 
-          {children && <div className="space-y-3 sm:space-y-4 border-l border-zinc-800/70 pl-3 sm:pl-4">{children}</div>}
+          {children && <div className="space-y-4 sm:space-y-6 border-l border-zinc-800/70 pl-4 sm:pl-6">{children}</div>}
         </div>
   </div>
     </article>

--- a/components/comments/ReplyForm.tsx
+++ b/components/comments/ReplyForm.tsx
@@ -33,7 +33,7 @@ const ReplyForm: React.FC<ReplyFormProps> = ({
         event.preventDefault();
         onSubmit(commentId, draft);
       }}
-      className="mt-3 space-y-3 rounded-2xl border border-zinc-800/80 bg-zinc-950/70 p-2.5 sm:p-3.5 text-sm"
+      className="mt-4 space-y-4 rounded-2xl border border-zinc-800/80 bg-zinc-950/70 p-4 sm:p-6 text-sm"
     >
       {requiresName && (
         <input
@@ -46,7 +46,7 @@ const ReplyForm: React.FC<ReplyFormProps> = ({
               nome: event.target.value,
             })
           }
-          className="w-full rounded-xl border border-zinc-800/70 bg-zinc-900/70 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
+          className="w-full rounded-xl border border-zinc-800/70 bg-zinc-900/70 px-4 py-2 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
           disabled={isSending}
         />
       )}
@@ -60,7 +60,7 @@ const ReplyForm: React.FC<ReplyFormProps> = ({
             comentario: event.target.value,
           })
         }
-        className="h-20 sm:h-24 w-full resize-none rounded-xl border border-zinc-800/70 bg-zinc-900/70 px-3 py-2 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
+        className="h-20 sm:h-24 w-full resize-none rounded-xl border border-zinc-800/70 bg-zinc-900/70 px-4 py-2 text-sm text-zinc-100 outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-500/40"
         disabled={isSending}
       />
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -71,14 +71,14 @@ const ReplyForm: React.FC<ReplyFormProps> = ({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded-xl border border-zinc-700/80 px-3 py-1.5 text-xs font-medium text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+            className="rounded-xl border border-zinc-700/80 px-4 py-2 text-xs font-medium text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
             disabled={isSending}
           >
             Cancelar
           </button>
           <button
             type="submit"
-            className="rounded-xl bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-purple-500 disabled:cursor-not-allowed disabled:bg-purple-800/60"
+            className="rounded-xl bg-purple-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-purple-500 disabled:cursor-not-allowed disabled:bg-purple-800/60"
             disabled={isSending}
           >
             {isSending ? "Enviando………" : "Responder"}

--- a/src/app/admin/CommentsModal.tsx
+++ b/src/app/admin/CommentsModal.tsx
@@ -79,26 +79,26 @@ export default function CommentsModal({
   const content = (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div className="mx-4 w-full max-w-2xl rounded-xl border border-zinc-800 bg-zinc-950">
-        <div className="flex items-center justify-between border-b border-zinc-800 px-4 py-3">
+        <div className="flex items-center justify-between border-b border-zinc-800 px-6 py-4">
           <h3 className="text-sm font-medium">Comentários</h3>
           <button
             onClick={onClose}
-            className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+            className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800"
           >
             Fechar
           </button>
         </div>
-        <div className="max-h-[60vh] overflow-y-auto px-4 py-3 text-sm">
+        <div className="max-h-[60vh] overflow-y-auto px-6 py-4 text-sm">
           {loading && <div className="text-zinc-400">Carregando...</div>}
           {error && <div className="text-red-400">{error}</div>}
           {!loading && !error && comments.length === 0 && (
             <div className="text-zinc-400">Nenhum comentário.</div>
           )}
-          <ul className="space-y-4">
+          <ul className="space-y-5">
             {comments.map((c: any) => (
-              <li key={c._id} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+              <li key={c._id} className="rounded-md border border-zinc-800 bg-zinc-900/40 p-4">
                 {mode === "all" ? (
-                  <div className="mb-2 flex items-center justify-between text-xs text-zinc-400">
+                  <div className="mb-4 flex items-center justify-between text-xs text-zinc-400">
                     <span>
                       <span className="text-zinc-500">Post:</span>{" "}
                       <Link href={`/posts/${c.postId}`} className="text-zinc-200 hover:underline">
@@ -109,20 +109,20 @@ export default function CommentsModal({
                     <span>{c.createdAt}</span>
                   </div>
                 ) : (
-                  <div className="mb-2 flex items-center justify-between text-xs text-zinc-400">
+                  <div className="mb-4 flex items-center justify-between text-xs text-zinc-400">
                     <span>{c.firstName || c.nome || "Usuário"}</span>
                     <span>{c.createdAt}</span>
                   </div>
                 )}
                 {mode === "all" ? (
-                  <div className="mb-2 text-xs text-zinc-400">Autor: {c.author || "Usuário"}</div>
+                  <div className="mb-4 text-xs text-zinc-400">Autor: {c.author || "Usuário"}</div>
                 ) : null}
                 <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: c.comentario }} />
                 {mode === "post" && Array.isArray(c.replies) && c.replies.length > 0 && (
-                  <ul className="mt-3 space-y-3 border-l border-zinc-800 pl-3">
+                  <ul className="mt-4 space-y-4 border-l border-zinc-800 pl-4">
                     {c.replies.map((r: any) => (
                       <li key={r._id}>
-                        <div className="mb-1 flex items-center justify-between text-xs text-zinc-500">
+                        <div className="mb-2 flex items-center justify-between text-xs text-zinc-500">
                           <span>{r.firstName || r.nome || "Usuário"}</span>
                           <span>{r.createdAt}</span>
                         </div>

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -26,7 +26,7 @@ function CheckboxBtn({ checked, onChange, label }: { checked: boolean; onChange:
       type="button"
       aria-pressed={checked}
       onClick={() => onChange(!checked)}
-      className={`inline-flex items-center gap-2 rounded-md border px-2 py-1 text-xs ${
+      className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-xs ${
         checked
           ? "border-zinc-500 bg-zinc-100 text-zinc-900"
           : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"
@@ -60,11 +60,11 @@ function TagListEditor({
     setEditing(false);
   };
   return (
-    <div className="flex flex-col gap-1">
-      <div className="flex flex-wrap gap-1">
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2">
         {values.length > 0 ? (
           values.map((t, i) => (
-            <span key={`${t}-${i}`} className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 text-xs text-zinc-300">
+            <span key={`${t}-${i}`} className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-300">
               {t}
             </span>
           ))
@@ -73,23 +73,23 @@ function TagListEditor({
         )}
       </div>
       {editing ? (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-4">
           <input
             value={text}
             onChange={(e) => setText(e.target.value)}
-            className="min-w-[160px] flex-1 rounded border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs"
+            className="min-w-[160px] flex-1 rounded border border-zinc-700 bg-zinc-950 px-3 py-2 text-xs"
             placeholder={`${label} separadas por vírgula`}
           />
           <button
             onClick={onSubmit}
             disabled={saving}
-            className="rounded border border-zinc-700 bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
+            className="rounded border border-zinc-700 bg-zinc-100 px-4 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
           >
             Salvar
           </button>
           <button
             onClick={() => setEditing(false)}
-            className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+            className="rounded border border-zinc-700 bg-zinc-900 px-4 py-2 text-xs text-zinc-200 hover:bg-zinc-800"
           >
             Cancelar
           </button>
@@ -100,7 +100,7 @@ function TagListEditor({
             setText(values.join(", "));
             setEditing(true);
           }}
-          className="self-start rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+          className="self-start rounded border border-zinc-700 bg-zinc-900 px-4 py-2 text-xs text-zinc-200 hover:bg-zinc-800"
         >
           Editar
         </button>
@@ -225,27 +225,27 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
       {selectedIds.length > 0 && (
         <tr className="border-t border-zinc-800 bg-zinc-900/60">
           <td className="px-4 py-2" colSpan={9}>
-            <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-4">
               <div className="text-sm text-zinc-300">{selectedIds.length} selecionado(s)</div>
               <div className="flex items-center gap-2">
                 <button
                   onClick={() => bulkAction("visibility", { hidden: false })}
                   disabled={bulkLoading}
-                  className="rounded-md border border-zinc-700 bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
+                  className="rounded-md border border-zinc-700 bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
                 >
                   Tornar visível
                 </button>
                 <button
                   onClick={() => bulkAction("visibility", { hidden: true })}
                   disabled={bulkLoading}
-                  className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60"
+                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60"
                 >
                   Ocultar
                 </button>
                 <button
                   onClick={() => bulkAction("delete")}
                   disabled={bulkLoading}
-                  className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-red-300 hover:bg-zinc-800 disabled:opacity-60"
+                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-red-300 hover:bg-zinc-800 disabled:opacity-60"
                 >
                   Excluir
                 </button>
@@ -256,7 +256,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
       )}
       <tr className="border-t border-zinc-800">
         <td className="px-4 py-2" colSpan={9}>
-          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-300">
+          <div className="flex flex-wrap items-center gap-4 text-xs text-zinc-300">
             <CheckboxBtn
               checked={allSelected}
               onChange={(next) => {
@@ -269,34 +269,34 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
             <span className="text-zinc-400">Ordenar por:</span>
             <button
               onClick={() => toggleSort("views")}
-              className={`rounded border px-2 py-1 ${sortKey === "views" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded border px-3 py-2 ${sortKey === "views" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
             >
               Views
             </button>
             <button
               onClick={() => toggleSort("date")}
-              className={`rounded border px-2 py-1 ${sortKey === "date" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded border px-3 py-2 ${sortKey === "date" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
             >
               Data
             </button>
             <button
               onClick={() => toggleSort("status")}
-              className={`rounded border px-2 py-1 ${sortKey === "status" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded border px-3 py-2 ${sortKey === "status" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
             >
               Visibilidade
             </button>
-            <div className="flex items-center gap-1 ml-2">
+            <div className="flex items-center gap-2 ml-2">
               <span className="text-zinc-400">Ordem:</span>
               <button
                 onClick={() => setSortOrder("asc")}
-                className={`rounded border px-2 py-1 ${sortOrder === "asc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+                className={`rounded border px-3 py-2 ${sortOrder === "asc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
                 title="Crescente"
               >
                 ↑
               </button>
               <button
                 onClick={() => setSortOrder("desc")}
-                className={`rounded border px-2 py-1 ${sortOrder === "desc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+                className={`rounded border px-3 py-2 ${sortOrder === "desc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
                 title="Decrescente"
               >
                 ↓
@@ -305,7 +305,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
             <span className="mx-2 h-4 w-px bg-zinc-800" />
             <button
               onClick={() => { setModalMode("all"); setModalPostId(null); setModalOpen(true); }}
-              className="rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-zinc-200 hover:bg-zinc-800"
+              className="rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-zinc-200 hover:bg-zinc-800"
             >
               Ver todos os comentários
             </button>
@@ -335,7 +335,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
                 setModalPostId(null);
                 setModalOpen(true);
               }}
-              className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+              className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800"
               title="Visualizar comentários"
             >
               {p.commentCount ?? 0} comentários
@@ -365,7 +365,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
           </td>
           <td className="px-4 py-2">
             <select
-              className="min-w-[160px] rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200"
+              className="min-w-[160px] rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200"
               value={p.coAuthorUserId ?? ""}
               onChange={async (e) => {
                 const next = e.target.value;
@@ -385,12 +385,12 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
       <tr>
         <td colSpan={9} className="px-4 py-3">
           <div className="flex items-center justify-center">
-            {error && <span className="text-red-500 text-sm mr-3">{error}</span>}
+            {error && <span className="text-red-500 text-sm mr-4">{error}</span>}
             {hasMore ? (
               <button
                 onClick={() => onLoadMore(false)}
                 disabled={loading}
-                className="inline-flex items-center justify-center rounded-md bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
+                className="inline-flex items-center justify-center rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
               >
                 {loading ? "Carregando..." : "Mostrar mais"}
               </button>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -41,16 +41,16 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               </li>
             </ul>
           </nav>
-          <div className="p-3 border-t border-zinc-800">
+          <div className="p-4 border-t border-zinc-800">
             <SignedIn>
-              <div className="flex items-center justify-between rounded-md bg-zinc-900 px-3 py-2">
+              <div className="flex items-center justify-between rounded-md bg-zinc-900 px-4 py-3">
                 <span className="text-xs text-zinc-400">Logado</span>
                 <UserButton appearance={{ elements: { userButtonPopoverCard: "bg-zinc-900" } }} />
               </div>
             </SignedIn>
             <SignedOut>
               <SignInButton>
-                <button className="w-full rounded-md bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200">
+                <button className="w-full rounded-md bg-zinc-100 px-4 py-3 text-sm font-medium text-zinc-900 hover:bg-zinc-200">
                   Entrar
                 </button>
               </SignInButton>
@@ -59,18 +59,18 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
         </aside>
         <div className="flex flex-col">
           <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/70 backdrop-blur supports-[backdrop-filter]:bg-zinc-950/60">
-            <div className="flex items-center justify-between gap-3 px-4 py-3 md:px-6">
+            <div className="flex items-center justify-between gap-4 px-6 py-4 md:px-8">
               <div className="md:hidden">
                 <Link href="/admin" className="font-semibold">Admin</Link>
               </div>
               <div className="flex-1" />
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-4">
                 <SignedIn>
                   <UserButton appearance={{ elements: { userButtonPopoverCard: "bg-zinc-900" } }} />
                 </SignedIn>
                 <SignedOut>
                   <SignInButton>
-                    <button className="rounded-md bg-zinc-100 px-3 py-1.5 text-xs font-medium text-zinc-900 hover:bg-zinc-200">
+                    <button className="rounded-md bg-zinc-100 px-4 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200">
                       Entrar
                     </button>
                   </SignInButton>
@@ -78,7 +78,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               </div>
             </div>
           </header>
-          <main className="p-4 md:p-6">{children}</main>
+          <main className="p-6 md:p-8">{children}</main>
         </div>
       </div>
     </div>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -54,7 +54,7 @@ export default async function UsersAdmin() {
                   </td>
                   <td className="px-4 py-3 text-zinc-300">{primaryEmail}</td>
                   <td className="px-4 py-3">
-                    <span className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300">
+                    <span className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-xs text-zinc-300">
                       {role ?? "-"}
                     </span>
                   </td>
@@ -63,11 +63,11 @@ export default async function UsersAdmin() {
                       const comments = commentsMap.get(user.id) ?? 0;
                       const total = comments + 0 + 0;
                       return (
-                        <div className="flex flex-col">
-                          <span className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300">
+                        <div className="flex flex-col gap-2">
+                          <span className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1 text-xs text-zinc-300">
                             Total: {total}
                           </span>
-                          <span className="mt-1 text-xs text-zinc-400">
+                          <span className="text-xs text-zinc-400">
                             Comentários: {comments} • Posts: 0 • Sugestões: 0
                           </span>
                         </div>
@@ -75,13 +75,13 @@ export default async function UsersAdmin() {
                     })()}
                   </td>
                   <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-2">
+                    <div className="flex items-center justify-end gap-3">
                       <form action={setRole} className="inline">
                         <input type="hidden" value={user.id} name="id" />
                         <input type="hidden" value="admin" name="role" />
                         <button
                           type="submit"
-                          className="rounded-md border border-zinc-700 bg-zinc-100 px-2 py-1 text-xs font-medium text-zinc-900 hover:bg-zinc-200"
+                          className="rounded-md border border-zinc-700 bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200"
                         >
                           Tornar Admin
                         </button>
@@ -91,7 +91,7 @@ export default async function UsersAdmin() {
                         <input type="hidden" value="moderator" name="role" />
                         <button
                           type="submit"
-                          className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                          className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800"
                         >
                           Tornar Moderator
                         </button>
@@ -100,7 +100,7 @@ export default async function UsersAdmin() {
                         <input type="hidden" value={user.id} name="id" />
                         <button
                           type="submit"
-                          className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1 text-xs text-red-300 hover:bg-zinc-800"
+                          className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-red-300 hover:bg-zinc-800"
                         >
                           Remover Papel
                         </button>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -83,7 +83,7 @@ h4 {
   @apply lg:text-3xl max-sm:text-xl font-bold;
 }
 h6 {
-  @apply text-sm font-extralight bg-zinc-950 p-0.5 rounded-md max-w-fit;
+  @apply text-sm font-extralight bg-zinc-950 px-2 py-1 rounded-md max-w-fit;
 }
 h1 {
   @apply sm:text-sm md:text-lg;

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -127,10 +127,10 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
   };
 
   return (
-    <section className="flex-1 gap-4">
-      <div className="flex items-center flex-wrap mb-4">
+    <section className="flex-1 gap-6">
+      <div className="flex items-center flex-wrap mb-6 gap-4">
         <h1 className="font-bold text-2xl">Blog</h1>
-        <div className="ml-1 sm:ml-2">
+        <div className="ml-2 sm:ml-4">
           <SearchBar
             onSearch={onSearch}
             initialQuery={query}
@@ -141,7 +141,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
                   aria-haspopup="listbox"
                   aria-expanded={openSort}
                   onClick={() => setOpenSort((v) => !v)}
-                  className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-sm hover:bg-zinc-700 transition-colors"
+                  className="inline-flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-zinc-700 transition-colors"
                 >
                   <span className="hidden sm:inline whitespace-nowrap">{currentSortLabel}</span>
                   <ChevronDownIcon className={`h-4 w-4 transition-transform duration-200 ${openSort ? "rotate-180" : "rotate-0"}`} />
@@ -149,7 +149,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
                 {openSort && (
                   <div
                     role="listbox"
-                    className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-zinc-700 bg-zinc-900 p-1 max-h-[200px] overflow-auto shadow-lg"
+                    className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-zinc-700 bg-zinc-900 p-2 max-h-[200px] overflow-auto shadow-lg"
                   >
                     {SORT_OPTIONS.map((opt) => {
                       const key = `${opt.value.sort ?? ""}:${opt.value.order ?? ""}`;
@@ -179,14 +179,14 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
       {error ? (
         <p className="text-red-500">{error}</p>
       ) : posts.length === 0 ? (
-        <div className="text-sm text-zinc-400">
+        <div className="text-sm text-zinc-400 space-y-2">
           <p>Nenhum post encontrado.</p>
-          <p className="mt-1">Tente ajustar a busca ou filtros.</p>
+          <p>Tente ajustar a busca ou filtros.</p>
         </div>
       ) : (
         <ul className="text-xl ml-0 flex flex-col gap-4">
           {posts.map((post) => (
-            <li key={post.postId} className="flex flex-col mb-1 group relative">
+            <li key={post.postId} className="flex flex-col mb-2 group relative">
               <Link
                 href={`/posts/${post.postId}`}
                 className="text-xl hover:underline"
@@ -194,8 +194,8 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
                 {post.title}
               </Link>
               <small className="text-zinc-400">
-                <Date dateString={post.date} /> <span aria-hidden className="mx-1">&middot;</span>
-                <span className="text-sm text-zinc-500 p-1">
+                <Date dateString={post.date} /> <span aria-hidden className="mx-2">&middot;</span>
+                <span className="inline-flex items-center rounded px-2 py-1 text-sm text-zinc-500">
                   {post.views ?? 0} views
                 </span>
               </small>


### PR DESCRIPTION
## Summary
- replace ad-hoc padding, margin, and gap values across comments, admin, and search interfaces with Tailwind scale spacing
- enlarge container and control spacing to better differentiate sections, nested blocks, and inline controls
- update global heading chip utility to use standard Tailwind padding helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd0ee215a483228926a1efff63018f