### PR TITLE
feat: enable paragraph-level post comments

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { sanitizeCommentHtml } from "@components/comments/utils";
+import type { ParagraphComment } from "../../types/paragraph-comments";
+
+const MAX_COMMENT_LENGTH = 480;
+
+function formatDateLabel(isoDate: string): string {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function buildRedirectUrl(): string {
+  if (typeof window === "undefined") {
+    return "/sign-in";
+  }
+  const search = window.location.search || "";
+  const hash = window.location.hash || "";
+  const target = `${window.location.pathname}${search}${hash}`;
+  return `/sign-in?redirect_url=${encodeURIComponent(target)}`;
+}
+
+type ParagraphCommentWidgetProps = {
+  postId: string;
+  paragraphId: string;
+  paragraphIndex: number;
+  coAuthorUserId?: string | null;
+  paragraphProps?: React.HTMLAttributes<HTMLParagraphElement>;
+  children: React.ReactNode;
+};
+
+export default function ParagraphCommentWidget({
+  postId,
+  paragraphId,
+  paragraphIndex,
+  coAuthorUserId,
+  paragraphProps,
+  children,
+}: ParagraphCommentWidgetProps) {
+  const { isLoaded, userId } = useAuth();
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [comments, setComments] = useState<ParagraphComment[]>([]);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  const loadComments = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const response = await fetch(
+        `/api/posts/${postId}/paragraph-comments?paragraphId=${encodeURIComponent(paragraphId)}`,
+        {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+          cache: "no-store",
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      const data = (await response.json()) as ParagraphComment[];
+      setComments(data);
+      setHasLoaded(true);
+      setErrorMessage(null);
+    } catch (error) {
+      console.error("Failed to load paragraph comments", error);
+      setErrorMessage("Não foi possível carregar os comentários agora.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [paragraphId, postId]);
+
+  const toggleComments = useCallback(async () => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!userId) {
+      window.location.href = buildRedirectUrl();
+      return;
+    }
+
+    if (!isExpanded && !hasLoaded) {
+      await loadComments();
+    }
+
+    setIsExpanded((prev) => !prev);
+  }, [hasLoaded, isExpanded, isLoaded, loadComments, userId]);
+
+  useEffect(() => {
+    if (!isLoaded || !userId) {
+      setIsAdmin(false);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const checkAdmin = async () => {
+      try {
+        const response = await fetch("/admin/api/check", {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+        const data = (await response.json()) as { isAdmin?: boolean };
+        if (!isCancelled) {
+          setIsAdmin(Boolean(data.isAdmin));
+        }
+      } catch (error) {
+        console.error("Failed to check admin status", error);
+        if (!isCancelled) {
+          setIsAdmin(false);
+        }
+      }
+    };
+
+    checkAdmin();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isLoaded, userId]);
+
+  const submitComment = useCallback(async () => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      setErrorMessage("Escreva algo antes de enviar.");
+      return;
+    }
+
+    if (trimmed.length > MAX_COMMENT_LENGTH) {
+      setErrorMessage(
+        `O comentário deve ter no máximo ${MAX_COMMENT_LENGTH} caracteres.`
+      );
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const response = await fetch(`/api/posts/${postId}/paragraph-comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          paragraphId,
+          content: trimmed,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+
+      const data = (await response.json()) as { comment: ParagraphComment };
+      setComments((prev) => [...prev, data.comment]);
+      setDraft("");
+      setErrorMessage(null);
+      if (!hasLoaded) {
+        setHasLoaded(true);
+      }
+    } catch (error) {
+      console.error("Failed to submit paragraph comment", error);
+      setErrorMessage("Não foi possível enviar seu comentário.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [draft, paragraphId, postId, hasLoaded]);
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!isLoaded || !userId || isSubmitting) {
+      if (!isLoaded) return;
+      if (!userId) {
+        window.location.href = buildRedirectUrl();
+      }
+      return;
+    }
+    await submitComment();
+  };
+
+  const handleDelete = useCallback(
+    async (commentId: string) => {
+      if (!isLoaded || !userId) {
+        return;
+      }
+
+      if (!isAdmin && !comments.some((comment) => comment._id === commentId && comment.userId === userId)) {
+        return;
+      }
+
+      const confirmed = window.confirm("Remover este comentário?");
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        setDeletingId(commentId);
+        const response = await fetch(
+          `/api/posts/${postId}/paragraph-comments/${commentId}`,
+          {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+
+        setComments((prev) => prev.filter((comment) => comment._id !== commentId));
+      } catch (error) {
+        console.error("Failed to delete paragraph comment", error);
+        setErrorMessage("Não foi possível remover o comentário.");
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [comments, isAdmin, isLoaded, postId, userId]
+  );
+
+  const formattedComments = useMemo(
+    () =>
+      comments
+        .slice()
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+        .map((comment) => ({
+          ...comment,
+          safeHtml: sanitizeCommentHtml(comment.content.replace(/\n/g, "<br />")),
+        })),
+    [comments]
+  );
+
+  const { className: incomingClassName, ...restParagraphProps } = paragraphProps ?? {};
+
+  const paragraphClassName = useMemo(() => {
+    const baseClass = "prose prose-zinc dark:prose-invert max-w-none";
+    const extra = incomingClassName ?? "";
+    return `${baseClass} ${extra}`.trim();
+  }, [incomingClassName]);
+
+  return (
+    <section className="flex flex-col gap-3" data-paragraph-id={paragraphId}>
+      <div className="flex items-start gap-3">
+        <p {...restParagraphProps} className={paragraphClassName}>
+          {children}
+        </p>
+        <button
+          type="button"
+          onClick={toggleComments}
+          className="flex shrink-0 items-center gap-1 rounded-full border border-zinc-300 bg-white px-3 py-1 text-sm font-medium text-zinc-600 shadow-sm transition hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"
+        >
+          <ChatBubbleLeftRightIcon className="h-4 w-4" />
+          <span className="hidden sm:inline">Comentar</span>
+        </button>
+      </div>
+
+      {isExpanded && (
+        <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/70">
+          <div className="flex items-center justify-between pb-3">
+            <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
+              Comentários deste parágrafo
+            </span>
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
+              Parágrafo {paragraphIndex + 1}
+            </span>
+          </div>
+
+          {errorMessage && (
+            <p className="mb-3 text-sm text-red-500" role="alert">
+              {errorMessage}
+            </p>
+          )}
+
+          <form className="flex flex-col gap-2" onSubmit={handleSubmit}>
+            <textarea
+              name="paragraph-comment"
+              value={draft}
+              onChange={(event) => {
+                setDraft(event.target.value);
+                if (errorMessage) {
+                  setErrorMessage(null);
+                }
+              }}
+              placeholder="Escreva seu comentário"
+              maxLength={MAX_COMMENT_LENGTH}
+              rows={3}
+              className="w-full resize-none rounded-lg border border-zinc-300 bg-transparent px-3 py-2 text-sm text-zinc-800 shadow-inner outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
+            />
+            <div className="flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">
+              <span>
+                {draft.length}/{MAX_COMMENT_LENGTH}
+              </span>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="inline-flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1 text-sm font-medium text-white transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:bg-zinc-400 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              >
+                {isSubmitting ? "Enviando..." : "Publicar"}
+              </button>
+            </div>
+          </form>
+
+          <div className="mt-4 space-y-3">
+            {isLoading ? (
+              <p className="text-sm text-zinc-500">Carregando comentários...</p>
+            ) : formattedComments.length === 0 ? (
+              <p className="text-sm text-zinc-500">
+                Ainda não há comentários neste parágrafo.
+              </p>
+            ) : (
+              formattedComments.map((comment) => (
+                <div key={comment._id} className="flex items-start gap-3">
+                  {comment.authorImageUrl ? (
+                    <img
+                      src={comment.authorImageUrl}
+                      alt={comment.authorName}
+                      className="h-8 w-8 rounded-full object-cover"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 text-sm font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-200">
+                      {comment.authorName.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="flex-1 rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm text-zinc-700 shadow-sm dark:border-zinc-700 dark:bg-zinc-800/80 dark:text-zinc-100">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <span className="font-semibold text-zinc-800 dark:text-white">
+                          {comment.authorName}
+                        </span>
+                        {coAuthorUserId && comment.userId === coAuthorUserId && (
+                          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-700 dark:bg-amber-500/10 dark:text-amber-300">
+                            co-autor
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-3 text-xs text-zinc-500 dark:text-zinc-400">
+                        <span>{formatDateLabel(comment.createdAt)}</span>
+                        {(isAdmin || comment.userId === userId) && (
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(comment._id)}
+                            disabled={deletingId === comment._id}
+                            className="text-xs font-medium text-red-500 transition hover:text-red-600 disabled:cursor-not-allowed disabled:text-red-300"
+                          >
+                            {deletingId === comment._id ? "Removendo..." : "Remover"}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                    <div
+                      className="mt-2 leading-relaxed"
+                      dangerouslySetInnerHTML={{ __html: comment.safeHtml }}
+                    />
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "dompurify": "^3.3.0",
         "dotenv": "^16.4.7",
         "gray-matter": "^4.0.3",
+        "html-react-parser": "^5.2.7",
         "minidenticons": "^4.2.1",
         "mongodb": "^6.13.1",
         "next": "^15.5.4",
@@ -29,7 +30,6 @@
         "openai": "^4.89.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-loading-skeleton": "^3.5.0",
         "remark": "^15.0.1",
         "remark-html": "^16.0.1"
       },
@@ -1256,7 +1256,7 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2054,6 +2054,59 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
@@ -2061,6 +2114,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dot-case": {
@@ -2116,6 +2183,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -2616,6 +2695,37 @@
       "integrity": "sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==",
       "license": "MIT"
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.1.tgz",
+      "integrity": "sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.0.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.7.tgz",
+      "integrity": "sha512-WzIAcqQoZoF49J9aev8NBDLz9TJvt2RmipeYA+/5+5x0sWCwFxqKiq0lysieiSA/G6dbUZ6KGGy65Cx2fjie5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.1",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.18"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -2636,6 +2746,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -2679,6 +2808,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4544,14 +4679,11 @@
         "react": "^19.0.0"
       }
     },
-    "node_modules/react-loading-skeleton": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-3.5.0.tgz",
-      "integrity": "sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4919,6 +5051,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.18.tgz",
+      "integrity": "sha512-JFPn62D4kJaPTnhFUI244MThx+FEGbi+9dw1b9yBBQ+1CZpV7QAT8kUtJ7b7EUNdHajjF/0x8fT+16oLJoojLg==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.11"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.11.tgz",
+      "integrity": "sha512-5A560JmXr7wDyGLK12Nq/EYS38VkGlglVzkis1JEdbGWSnbQIEhZzTJhzURXN5/8WwwFCs/f/VVcmkTppbXLow==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dompurify": "^3.3.0",
     "dotenv": "^16.4.7",
     "gray-matter": "^4.0.3",
+    "html-react-parser": "^5.2.7",
     "minidenticons": "^4.2.1",
     "mongodb": "^6.13.1",
     "next": "^15.5.4",

--- a/src/app/admin/ParagraphCommentsToggle.tsx
+++ b/src/app/admin/ParagraphCommentsToggle.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export default function ParagraphCommentsToggle({
+  postId,
+  enabled: initialEnabled,
+  onToggle,
+}: {
+  postId: string;
+  enabled?: boolean;
+  onToggle?: (next: boolean) => void;
+}) {
+  const [enabled, setEnabled] = useState(initialEnabled !== false);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = () => {
+    startTransition(async () => {
+      setError(null);
+      try {
+        const next = !enabled;
+        const res = await fetch("/admin/api/paragraph-comments", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postId, enabled: next }),
+        });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || "Falha ao atualizar comentários por parágrafo");
+        }
+        setEnabled(next);
+        onToggle?.(next);
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    });
+  };
+
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <button
+        onClick={toggle}
+        disabled={isPending}
+        className={`px-2 py-1 rounded text-xs border ${
+          enabled
+            ? "bg-emerald-500/10 text-emerald-300 border-emerald-400/40"
+            : "bg-zinc-900 text-zinc-200 border-zinc-700"
+        } disabled:opacity-60`}
+        title={enabled ? "Desativar comentários por parágrafo" : "Ativar comentários por parágrafo"}
+      >
+        {enabled ? "Ativos" : "Inativos"}
+      </button>
+      {error && <span className="text-red-500 text-xs">{error}</span>}
+    </div>
+  );
+}

--- a/src/app/admin/ParagraphCommentsToggle.tsx
+++ b/src/app/admin/ParagraphCommentsToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
 export default function ParagraphCommentsToggle({
   postId,
@@ -14,6 +14,10 @@ export default function ParagraphCommentsToggle({
   const [enabled, setEnabled] = useState(initialEnabled !== false);
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEnabled(initialEnabled !== false);
+  }, [initialEnabled]);
 
   const toggle = () => {
     startTransition(async () => {

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import VisibilityToggle from "./VisibilityToggle";
+import ParagraphCommentsToggle from "./ParagraphCommentsToggle";
 import CommentsModal from "./CommentsModal";
 
 type PostRow = {
@@ -15,6 +16,7 @@ type PostRow = {
   tags?: string[];
   categories?: string[];
   coAuthorUserId?: string | null;
+  paragraphCommentsEnabled?: boolean;
 };
 
 type SortKey = "date" | "views" | "status";
@@ -224,7 +226,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
     <>
       {selectedIds.length > 0 && (
         <tr className="border-t border-zinc-800 bg-zinc-900/60">
-          <td className="px-4 py-2" colSpan={9}>
+          <td className="px-4 py-2" colSpan={11}>
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div className="text-sm text-zinc-300">{selectedIds.length} selecionado(s)</div>
               <div className="flex items-center gap-2">
@@ -255,7 +257,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
         </tr>
       )}
       <tr className="border-t border-zinc-800">
-        <td className="px-4 py-2" colSpan={9}>
+        <td className="px-4 py-2" colSpan={11}>
           <div className="flex flex-wrap items-center gap-4 text-xs text-zinc-300">
             <CheckboxBtn
               checked={allSelected}
@@ -379,11 +381,26 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
               ))}
             </select>
           </td>
+          <td className="px-4 py-2 text-right">
+            <ParagraphCommentsToggle
+              postId={p.postId}
+              enabled={p.paragraphCommentsEnabled !== false}
+              onToggle={(next) =>
+                setPosts((rows) =>
+                  rows.map((r) =>
+                    r.postId === p.postId
+                      ? { ...r, paragraphCommentsEnabled: next }
+                      : r
+                  )
+                )
+              }
+            />
+          </td>
           <td className="px-4 py-2 text-right"><VisibilityToggle postId={p.postId} hidden={p.hidden} /></td>
         </tr>
       ))}
       <tr>
-        <td colSpan={9} className="px-4 py-3">
+        <td colSpan={11} className="px-4 py-3">
           <div className="flex items-center justify-center">
             {error && <span className="text-red-500 text-sm mr-4">{error}</span>}
             {hasMore ? (

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -335,8 +335,8 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
           <td className="px-4 py-2 text-right">
             <button
               onClick={() => {
-                setModalMode("all");
-                setModalPostId(null);
+                setModalMode("post");
+                setModalPostId(p.postId);
                 setModalOpen(true);
               }}
               className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800"

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -165,9 +165,11 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
   }
 
   useEffect(() => {
-    // Reset and fetch when sorting changes
-    setPosts([]);
+    // Reset and fetch when sorting changes. We keep the previous list visible
+    // until the new request succeeds to avoid wiping the dashboard in case the
+    // network call falhe (por exemplo, quando o Redis não está configurado).
     setHasMore(true);
+    setError(null);
     void onLoadMore(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortKey, sortOrder]);

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,14 +1,14 @@
 "use server";
-import { auth } from "@clerk/nextjs/server";
 import { Roles } from "types/globals";
 import { revalidatePath } from "next/cache";
 import { getClerkServerClient } from "../../lib/clerk-server";
+import { resolveAdminStatus } from "../../lib/admin";
 
 export async function setRole(formData: FormData) {
-  const { sessionClaims } = await auth();
+  const { isAdmin } = await resolveAdminStatus();
 
   // Check that the user trying to set the role is an admin
-  if (sessionClaims?.metadata?.role !== "admin") {
+  if (!isAdmin) {
     throw new Error("Not Authorized");
   }
 
@@ -27,9 +27,9 @@ export async function setRole(formData: FormData) {
 }
 
 export async function removeRole(formData: FormData) {
-  const { sessionClaims } = await auth();
+  const { isAdmin } = await resolveAdminStatus();
 
-  if (sessionClaims?.metadata?.role !== "admin") {
+  if (!isAdmin) {
     throw new Error("Not Authorized");
   }
 

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -1,8 +1,8 @@
 "use server";
 import { auth } from "@clerk/nextjs/server";
-import { clerkClient } from "@clerk/nextjs/server";
 import { Roles } from "types/globals";
 import { revalidatePath } from "next/cache";
+import { getClerkServerClient } from "../../lib/clerk-server";
 
 export async function setRole(formData: FormData) {
   const { sessionClaims } = await auth();
@@ -12,11 +12,11 @@ export async function setRole(formData: FormData) {
     throw new Error("Not Authorized");
   }
 
-  const client = await clerkClient();
   const id = formData.get("id") as string;
   const role = formData.get("role") as Roles;
 
   try {
+    const client = await getClerkServerClient();
     await client.users.updateUser(id, {
       publicMetadata: { role },
     });
@@ -33,10 +33,10 @@ export async function removeRole(formData: FormData) {
     throw new Error("Not Authorized");
   }
 
-  const client = await clerkClient();
   const id = formData.get("id") as string;
 
   try {
+    const client = await getClerkServerClient();
     await client.users.updateUser(id, {
       publicMetadata: { role: null },
     });

--- a/src/app/admin/api/[...action]/route.ts
+++ b/src/app/admin/api/[...action]/route.ts
@@ -1,8 +1,6 @@
 "use server";
-import { auth } from "@clerk/nextjs/server";
-import { clerkClient } from "@clerk/nextjs/server";
-import { Roles } from "types/globals";
 import { NextResponse } from "next/server"; // Para criar respostas JSON
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 export async function GET(
   req: Request,
@@ -15,8 +13,8 @@ export async function GET(
     return NextResponse.json({ error: "Invalid action" }, { status: 400 });
   }
 
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ isAdmin: false }, { status: 200 });
   }
 

--- a/src/app/admin/api/comments/route.ts
+++ b/src/app/admin/api/comments/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 type AdminComment = {
   _id: string;
@@ -12,8 +12,8 @@ type AdminComment = {
 };
 
 export async function GET(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/api/editor/route.ts
+++ b/src/app/admin/api/editor/route.ts
@@ -1,13 +1,13 @@
-﻿import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-import { clientPromise } from "../../../../lib/mongo"; // ConexÃ£o com o MongoDB
+import { NextResponse } from "next/server";
+import { clientPromise } from "../../../../lib/mongo"; // Conexão com o MongoDB
+import { resolveAdminStatus } from "../../../../lib/admin";
 
-// Handler para POST requests (publicaÃ§Ã£o de posts)
+// Handler para POST requests (publicação de posts)
 export async function POST(req: Request) {
-  const { sessionClaims } = await auth();
+  const { isAdmin } = await resolveAdminStatus();
 
-  // Verifica se o usuÃ¡rio Ã© um admin
-  if (sessionClaims?.metadata?.role !== "admin") {
+  // Verifica se o usuário é um admin
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
     const db = client.db("blog");
     const postsCollection = db.collection("posts");
 
-    // Verifica se jÃ¡ existe um post com o mesmo postId
+    // Verifica se já existe um post com o mesmo postId
     const existingPost = await postsCollection.findOne({ postId });
     if (existingPost) {
       return NextResponse.json(
@@ -93,7 +93,7 @@ export async function POST(req: Request) {
     const newPost = {
       postId,
       title,
-      htmlContent: content, // Armazena o conteÃºdo como Markdown (htmlContent para consistÃªncia com o projeto)
+      htmlContent: content, // Armazena o conteúdo como Markdown (htmlContent para consistência com o projeto)
       date: new Date().toISOString().split("T")[0], // Formato "YYYY-MM-DD"
       views: 0, // Inicializa as views como 0
       audioUrl: normalizedAudioUrl,
@@ -122,5 +122,3 @@ export async function POST(req: Request) {
     );
   }
 }
-
-

--- a/src/app/admin/api/editor/route.ts
+++ b/src/app/admin/api/editor/route.ts
@@ -23,6 +23,11 @@ export async function POST(req: Request) {
     const coAuthorUserId = formData.get("coAuthorUserId");
     const hiddenRaw = formData.get("hidden");
     const hidden = hiddenRaw === "true" || hiddenRaw === "on";
+    const paragraphCommentsRaw = formData.get("paragraphCommentsEnabled");
+    const paragraphCommentsEnabled =
+      paragraphCommentsRaw === "false"
+        ? false
+        : !(paragraphCommentsRaw === null || paragraphCommentsRaw === "false");
 
     // Valida os dados de entrada
     if (!title || typeof title !== "string") {
@@ -97,6 +102,7 @@ export async function POST(req: Request) {
       friendImage: normalizedFriendImage,
       coAuthorUserId: normalizedCoAuthorUserId,
       hidden,
+      paragraphCommentsEnabled,
     };
 
     await postsCollection.insertOne(newPost);

--- a/src/app/admin/api/paragraph-comments/route.ts
+++ b/src/app/admin/api/paragraph-comments/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+
+import { getMongoDb } from "../../../../lib/mongo";
+
+export async function POST(req: Request) {
+  const { sessionClaims } = await auth();
+  if (sessionClaims?.metadata?.role !== "admin") {
+    return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const postId = typeof (body as any)?.postId === "string" ? (body as any).postId : null;
+  const enabledRaw = (body as any)?.enabled;
+  if (!postId || typeof enabledRaw !== "boolean") {
+    return NextResponse.json(
+      { error: "Post ID and enabled flag are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const db = await getMongoDb();
+    const posts = db.collection("posts");
+    const result = await posts.updateOne(
+      { postId },
+      { $set: { paragraphCommentsEnabled: enabledRaw } }
+    );
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { message: "Parágrafo atualizado", postId, enabled: enabledRaw },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error updating paragraph comments flag:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/admin/api/paragraph-comments/route.ts
+++ b/src/app/admin/api/paragraph-comments/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 
 import { getMongoDb } from "../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 export async function POST(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/api/paragraph-comments/route.ts
+++ b/src/app/admin/api/paragraph-comments/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
 
 import { getMongoDb } from "../../../../lib/mongo";
 
@@ -36,10 +37,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
 
-    return NextResponse.json(
-      { message: "Parágrafo atualizado", postId, enabled: enabledRaw },
-      { status: 200 }
-    );
+    revalidatePath(`/posts/${postId}`);
+    revalidatePath("/admin");
+
+    return NextResponse.json({ message: "Parágrafo atualizado", postId, enabled: enabledRaw }, { status: 200 });
   } catch (error) {
     console.error("Error updating paragraph comments flag:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/admin/api/posts/bulk/route.ts
+++ b/src/app/admin/api/posts/bulk/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../../lib/admin";
 
 type BulkBody =
   | { action: "visibility"; postIds: string[]; hidden: boolean }
   | { action: "delete"; postIds: string[] };
 
 export async function POST(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/api/posts/route.ts
+++ b/src/app/admin/api/posts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../lib/mongo";
 import { Redis } from "@upstash/redis";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 // Redis instance (for counting replies). When the environment variables are not
 // provided we still want the dashboard to work, so we attempt to instantiate it
@@ -19,8 +19,8 @@ try {
 }
 
 export async function GET(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 
@@ -132,8 +132,8 @@ export async function GET(req: Request) {
 }
 
 export async function PATCH(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/api/posts/route.ts
+++ b/src/app/admin/api/posts/route.ts
@@ -23,7 +23,18 @@ export async function GET(req: Request) {
     const db = client.db("blog");
     const postsCollection = db.collection("posts");
 
-    const projection = { _id: 0, postId: 1, title: 1, date: 1, views: 1, hidden: 1, tags: 1, categories: 1, coAuthorUserId: 1 } as const;
+    const projection = {
+      _id: 0,
+      postId: 1,
+      title: 1,
+      date: 1,
+      views: 1,
+      hidden: 1,
+      tags: 1,
+      categories: 1,
+      coAuthorUserId: 1,
+      paragraphCommentsEnabled: 1,
+    } as const;
 
     // Build sort doc
     let sortDoc: Record<string, 1 | -1> = { date: -1 };
@@ -95,6 +106,8 @@ export async function GET(req: Request) {
         : (p as any).categories
         ? [String((p as any).categories)]
         : [],
+      paragraphCommentsEnabled:
+        (p as any).paragraphCommentsEnabled === false ? false : true,
     }));
 
     const hasMore = offset + posts.length < total;

--- a/src/app/admin/api/users/route.ts
+++ b/src/app/admin/api/users/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
-
 import { getClerkServerClient } from "../../../../lib/clerk-server";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 export async function GET() {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/api/users/route.ts
+++ b/src/app/admin/api/users/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
+
+import { getClerkServerClient } from "../../../../lib/clerk-server";
 
 export async function GET() {
   const { sessionClaims } = await auth();
@@ -8,7 +10,7 @@ export async function GET() {
   }
 
   try {
-    const client = await clerkClient();
+    const client = await getClerkServerClient();
     const list = await client.users.getUserList();
     const users = list.data.map((u) => ({
       id: u.id,

--- a/src/app/admin/api/visibility/route.ts
+++ b/src/app/admin/api/visibility/route.ts
@@ -1,10 +1,10 @@
 ﻿import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 export async function POST(req: Request) {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -11,6 +11,7 @@ export default function Editor() {
   const [hasAudio, setHasAudio] = useState(false);
   const [audioUrl, setAudioUrl] = useState("");
   const [hidden, setHidden] = useState(false);
+  const [paragraphCommentsEnabled, setParagraphCommentsEnabled] = useState(true);
   const [content, setContent] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -37,7 +38,13 @@ export default function Editor() {
         formData.append("audioUrl", audioUrl);
       }
 
-      formData.append("hidden", hidden ? "true" : "false");      const response = await fetch("/admin/api/editor", {
+      formData.append("hidden", hidden ? "true" : "false");
+      formData.append(
+        "paragraphCommentsEnabled",
+        paragraphCommentsEnabled ? "true" : "false"
+      );
+
+      const response = await fetch("/admin/api/editor", {
         method: "POST",
         body: formData,
       });
@@ -57,6 +64,7 @@ export default function Editor() {
       setHasAudio(false);
       setAudioUrl("");
       setHidden(false);
+      setParagraphCommentsEnabled(true);
       setContent("");
     } catch (error) {
       setError("Falha ao criar o post: " + (error as Error).message);
@@ -115,6 +123,22 @@ export default function Editor() {
                 className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-500"
               />
               Ocultar post (não aparecer em listagens públicas)
+            </label>
+          </div>
+
+          <div className="flex items-center rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-3">
+            <label
+              htmlFor="paragraph-comments"
+              className="flex items-center justify-between gap-3 w-full text-sm"
+            >
+              <span>Permitir comentários por parágrafo</span>
+              <input
+                type="checkbox"
+                id="paragraph-comments"
+                checked={paragraphCommentsEnabled}
+                onChange={(e) => setParagraphCommentsEnabled(e.target.checked)}
+                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-500"
+              />
             </label>
           </div>
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,9 @@
 ﻿import Link from "next/link";
 import { notFound } from "next/navigation";
-import { auth } from "@clerk/nextjs/server";
 import { getMongoDb } from "../../lib/mongo";
 import VisibilityToggle from "./VisibilityToggle";
 import RecentPostsClient from "./RecentPostsClient";
+import { resolveAdminStatus } from "../../lib/admin";
 
 type PostRow = {
   _id?: string;
@@ -16,8 +16,8 @@ type PostRow = {
 };
 
 export default async function AdminDashboard() {
-  const { sessionClaims } = await auth();
-  if (sessionClaims?.metadata?.role !== "admin") {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
     notFound();
   }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -12,6 +12,7 @@ type PostRow = {
   date?: string;
   views?: number;
   hidden?: boolean;
+  paragraphCommentsEnabled?: boolean;
 };
 
 export default async function AdminDashboard() {
@@ -33,7 +34,21 @@ export default async function AdminDashboard() {
       .toArray()
       .then((arr) => arr[0]?.totalViews ?? 0),
     postsCollection
-      .find({}, { projection: { _id: 0, postId: 1, title: 1, date: 1, views: 1, coAuthorUserId: 1 } })
+      .find(
+        {},
+        {
+          projection: {
+            _id: 0,
+            postId: 1,
+            title: 1,
+            date: 1,
+            views: 1,
+            coAuthorUserId: 1,
+            paragraphCommentsEnabled: 1,
+            hidden: 1,
+          },
+        }
+      )
       .sort({ date: -1 })
       .limit(6)
       .toArray() as unknown as Promise<PostRow[]>,
@@ -84,6 +99,7 @@ export default async function AdminDashboard() {
                 <th className="px-4 py-2 font-medium">Tags</th>
                 <th className="px-4 py-2 font-medium">Categorias</th>
                 <th className="px-4 py-2 font-medium">Co-autor</th>
+                <th className="px-4 py-2 font-medium text-right">Parágrafos</th>
                 <th className="px-4 py-2 font-medium text-right">Visibilidade</th>
               </tr>
             </thead>
@@ -91,7 +107,7 @@ export default async function AdminDashboard() {
               <RecentPostsClient initial={latest as any} />
               {latest.length === 0 && (
                 <tr>
-                  <td colSpan={10} className="px-4 py-8 text-center text-zinc-400">
+                  <td colSpan={11} className="px-4 py-8 text-center text-zinc-400">
                     Nenhum post encontrado.
                   </td>
                 </tr>

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { clerkClient } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
+import { getClerkServerClient } from "../../../lib/clerk-server";
 
 export async function setRole(formData: FormData) {
   const id = formData.get("id");
@@ -9,7 +9,7 @@ export async function setRole(formData: FormData) {
   if (!id || typeof id !== "string") throw new Error("Missing user id");
   if (!role || typeof role !== "string") throw new Error("Missing role");
 
-  const client = await clerkClient();
+  const client = await getClerkServerClient();
   await client.users.updateUser(id, {
     publicMetadata: { role },
   });
@@ -21,7 +21,7 @@ export async function removeRole(formData: FormData) {
   const id = formData.get("id");
   if (!id || typeof id !== "string") throw new Error("Missing user id");
 
-  const client = await clerkClient();
+  const client = await getClerkServerClient();
   await client.users.updateUser(id, {
     publicMetadata: { role: null },
   });

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -2,8 +2,12 @@
 
 import { revalidatePath } from "next/cache";
 import { getClerkServerClient } from "../../../lib/clerk-server";
+import { resolveAdminStatus } from "../../../lib/admin";
 
 export async function setRole(formData: FormData) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) throw new Error("Not Authorized");
+
   const id = formData.get("id");
   const role = formData.get("role");
   if (!id || typeof id !== "string") throw new Error("Missing user id");
@@ -18,6 +22,9 @@ export async function setRole(formData: FormData) {
 }
 
 export async function removeRole(formData: FormData) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) throw new Error("Not Authorized");
+
   const id = formData.get("id");
   if (!id || typeof id !== "string") throw new Error("Missing user id");
 

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,9 +1,9 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import { setRole, removeRole } from "./actions";
 import { getMongoDb } from "../../../lib/mongo";
+import { getClerkServerClient } from "../../../lib/clerk-server";
 
 export default async function UsersAdmin() {
-  const client = await clerkClient();
+  const client = await getClerkServerClient();
   const users = (await client.users.getUserList()).data;
 
   // Aggregate contributions (comments only for now)

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,8 +1,15 @@
+import { notFound } from "next/navigation";
 import { setRole, removeRole } from "./actions";
 import { getMongoDb } from "../../../lib/mongo";
 import { getClerkServerClient } from "../../../lib/clerk-server";
+import { resolveAdminStatus } from "../../../lib/admin";
 
 export default async function UsersAdmin() {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    notFound();
+  }
+
   const client = await getClerkServerClient();
   const users = (await client.users.getUserList()).data;
 

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -6,6 +6,7 @@ import axios from "axios";
 import { ObjectId } from "mongodb";
 import { remark } from "remark";
 import html from "remark-html";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 // Configuração do Redis Upstash
 const redis = Redis.fromEnv();
@@ -408,18 +409,14 @@ export async function DELETE(
 ) {
   const { id: commentId } = await params;
   const { userId, sessionClaims } = await auth();
-  const user = await currentUser();
+  const { isAdmin } = await resolveAdminStatus({ sessionClaims, userId });
 
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const isAdmin =
-    user?.unsafeMetadata?.role === "admin" ||
-    sessionClaims?.metadata?.role === "admin";
   console.log("Admin check:", {
     userId,
-    unsafeMetadataRole: user?.unsafeMetadata?.role,
     sessionClaimsRole: sessionClaims?.metadata?.role,
     isAdmin,
   });

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,22 +1,15 @@
 import { NextResponse } from "next/server";
-import { auth, currentUser } from "@clerk/nextjs/server";
+import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../lib/mongo";
 import { remark } from "remark";
 import html from "remark-html";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 async function resolveIsAdminFromRequest(): Promise<boolean> {
   try {
-    const { sessionClaims } = await auth();
-    if (sessionClaims?.metadata?.role === "admin") {
-      return true;
-    }
-    const user = await currentUser();
-    const metadataSources = [
-      user?.publicMetadata,
-      user?.unsafeMetadata,
-      user?.privateMetadata,
-    ] as Array<Record<string, unknown> | null | undefined>;
-    return metadataSources.some((meta) => meta?.role === "admin");
+    const { sessionClaims, userId } = await auth();
+    const { isAdmin } = await resolveAdminStatus({ sessionClaims, userId });
+    return isAdmin;
   } catch (error) {
     return false;
   }

--- a/src/app/api/posts/[postId]/paragraph-comments/[commentId]/route.ts
+++ b/src/app/api/posts/[postId]/paragraph-comments/[commentId]/route.ts
@@ -39,6 +39,27 @@ export async function DELETE(
     (user?.unsafeMetadata as Record<string, unknown> | undefined)?.role === "admin";
 
   const db = await getMongoDb();
+  const postsCollection = db.collection("posts");
+  const post = await postsCollection.findOne(
+    { postId },
+    { projection: { _id: 1, hidden: 1, paragraphCommentsEnabled: 1 } }
+  );
+
+  if (!post) {
+    return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+  }
+
+  if ((post as any).hidden === true && !isAdmin) {
+    return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+  }
+
+  if ((post as any).paragraphCommentsEnabled === false && !isAdmin) {
+    return NextResponse.json(
+      { error: "Comentários por parágrafo desativados para este post." },
+      { status: 403 }
+    );
+  }
+
   const collection = db.collection<ParagraphCommentDocument>(COLLECTION_NAME);
 
   let objectId: ObjectId;

--- a/src/app/api/posts/[postId]/paragraph-comments/[commentId]/route.ts
+++ b/src/app/api/posts/[postId]/paragraph-comments/[commentId]/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { ObjectId } from "mongodb";
+
+import { getMongoDb } from "../../../../../../lib/mongo";
+
+const COLLECTION_NAME = "paragraph-comments";
+
+type ParagraphCommentDocument = {
+  _id: ObjectId;
+  postId: string;
+  paragraphId: string;
+  userId: string;
+};
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ postId: string; commentId: string }> }
+) {
+  const resolvedParams = await params;
+  const postId = resolvedParams?.postId;
+  const commentId = resolvedParams?.commentId;
+
+  if (!postId || !commentId) {
+    return NextResponse.json(
+      { error: "Identificador inválido." },
+      { status: 400 }
+    );
+  }
+
+  const { userId, sessionClaims } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Não autorizado." }, { status: 401 });
+  }
+
+  const user = await currentUser();
+  const isAdmin =
+    sessionClaims?.metadata?.role === "admin" ||
+    (user?.unsafeMetadata as Record<string, unknown> | undefined)?.role === "admin";
+
+  const db = await getMongoDb();
+  const collection = db.collection<ParagraphCommentDocument>(COLLECTION_NAME);
+
+  let objectId: ObjectId;
+  try {
+    objectId = new ObjectId(commentId);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Comentário inválido." },
+      { status: 400 }
+    );
+  }
+
+  const existing = await collection.findOne({ _id: objectId, postId });
+  if (!existing) {
+    return NextResponse.json({ error: "Comentário não encontrado." }, { status: 404 });
+  }
+
+  if (!isAdmin && existing.userId !== userId) {
+    return NextResponse.json({ error: "Sem permissão." }, { status: 403 });
+  }
+
+  await collection.deleteOne({ _id: objectId, postId });
+
+  return NextResponse.json({ success: true }, { status: 200 });
+}

--- a/src/app/api/posts/[postId]/paragraph-comments/route.ts
+++ b/src/app/api/posts/[postId]/paragraph-comments/route.ts
@@ -1,0 +1,183 @@
+import { NextResponse } from "next/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { ObjectId } from "mongodb";
+
+import { getMongoDb } from "../../../../../lib/mongo";
+import type { ParagraphComment } from "../../../../../../types/paragraph-comments";
+
+const COLLECTION_NAME = "paragraph-comments";
+const MAX_LENGTH = 480;
+
+type ParagraphCommentDocument = {
+  _id: ObjectId;
+  postId: string;
+  paragraphId: string;
+  userId: string;
+  authorName: string;
+  authorImageUrl: string | null;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const mapDocumentToResponse = (
+  document: ParagraphCommentDocument
+): ParagraphComment => ({
+  _id: document._id.toString(),
+  postId: document.postId,
+  paragraphId: document.paragraphId,
+  userId: document.userId,
+  authorName: document.authorName,
+  authorImageUrl: document.authorImageUrl,
+  content: document.content,
+  createdAt: document.createdAt,
+  updatedAt: document.updatedAt,
+});
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const resolvedParams = await params;
+  const postId = resolvedParams?.postId;
+  if (!postId) {
+    return NextResponse.json(
+      { error: "Post ID inválido." },
+      { status: 400 }
+    );
+  }
+
+  const url = new URL(req.url);
+  const paragraphId = url.searchParams.get("paragraphId");
+
+  if (!paragraphId) {
+    return NextResponse.json(
+      { error: "Parágrafo não informado." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const db = await getMongoDb();
+    const collection = db.collection<ParagraphCommentDocument>(COLLECTION_NAME);
+
+    const documents = await collection
+      .find({ postId, paragraphId })
+      .sort({ createdAt: 1 })
+      .toArray();
+
+    const comments = documents.map(mapDocumentToResponse);
+
+    return NextResponse.json(comments, { status: 200 });
+  } catch (error) {
+    console.error("Failed to fetch paragraph comments", error);
+    return NextResponse.json(
+      { error: "Erro interno ao buscar comentários." },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const resolvedParams = await params;
+  const postId = resolvedParams?.postId;
+  if (!postId) {
+    return NextResponse.json(
+      { error: "Post ID inválido." },
+      { status: 400 }
+    );
+  }
+
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Não autorizado." }, { status: 401 });
+  }
+
+  const user = await currentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Usuário não encontrado." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Formato de requisição inválido." },
+      { status: 400 }
+    );
+  }
+
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !("paragraphId" in body) ||
+    !("content" in body)
+  ) {
+    return NextResponse.json(
+      { error: "Dados insuficientes." },
+      { status: 400 }
+    );
+  }
+
+  const paragraphId = String((body as Record<string, unknown>).paragraphId || "").trim();
+  const content = String((body as Record<string, unknown>).content || "").trim();
+
+  if (!paragraphId) {
+    return NextResponse.json(
+      { error: "Parágrafo inválido." },
+      { status: 400 }
+    );
+  }
+
+  if (!content) {
+    return NextResponse.json(
+      { error: "Escreva um comentário antes de enviar." },
+      { status: 400 }
+    );
+  }
+
+  if (content.length > MAX_LENGTH) {
+    return NextResponse.json(
+      { error: `O comentário deve ter no máximo ${MAX_LENGTH} caracteres.` },
+      { status: 400 }
+    );
+  }
+
+  const now = new Date().toISOString();
+  const authorName =
+    user.fullName || user.firstName || user.username || "Leitor";
+  const authorImageUrl = user.imageUrl ?? null;
+
+  const document: ParagraphCommentDocument = {
+    _id: new ObjectId(),
+    postId,
+    paragraphId,
+    userId,
+    authorName,
+    authorImageUrl,
+    content,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  try {
+    const db = await getMongoDb();
+    const collection = db.collection<ParagraphCommentDocument>(COLLECTION_NAME);
+    await collection.insertOne(document);
+
+    return NextResponse.json(
+      { comment: mapDocumentToResponse(document) },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Failed to save paragraph comment", error);
+    return NextResponse.json(
+      { error: "Erro ao salvar o comentário." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -87,8 +87,7 @@ async function resolveIsAdmin(): Promise<boolean> {
   try {
     const { isAdmin } = await resolveAdminStatus();
     return isAdmin;
-  } catch (error) {
-    console.error("Failed to resolve admin role:", error);
+  } catch {
     return false;
   }
 }

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -221,6 +221,7 @@ export default async function PostPage({ params }: PostPageProps) {
         initialViews={views}
         audioUrl={post.audioUrl}
         readingTime={readingTime}
+        coAuthorUserId={post.coAuthorUserId ?? null}
       />
       <BackHome />
       <Comment postId={post.postId} coAuthorUserId={post.coAuthorUserId ?? undefined} />

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -204,8 +204,8 @@ export default async function PostPage({ params }: PostPageProps) {
   let coAuthorImageUrl: string | null = null;
   try {
     if (post.coAuthorUserId) {
-      const { clerkClient } = await import("@clerk/nextjs/server");
-      const client = await clerkClient();
+      const { getClerkServerClient } = await import("../../../lib/clerk-server");
+      const client = await getClerkServerClient();
       const user = await client.users.getUser(post.coAuthorUserId);
       coAuthorImageUrl = user.imageUrl ?? null;
     }

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -20,6 +20,7 @@ type PostContentClientProps = {
   audioUrl?: string;
   readingTime: string;
   coAuthorUserId?: string | null;
+  paragraphCommentsEnabled: boolean;
 };
 
 export default function PostContentClient({
@@ -30,6 +31,7 @@ export default function PostContentClient({
   audioUrl,
   readingTime,
   coAuthorUserId,
+  paragraphCommentsEnabled,
 }: PostContentClientProps) {
   const [views, setViews] = useState(initialViews);
 
@@ -67,7 +69,7 @@ export default function PostContentClient({
 
     return parse(htmlContent, {
       replace: (node: DOMNode) => {
-        if (node.type === "tag" && node.name === "p") {
+        if (node.type === "tag" && node.name === "p" && paragraphCommentsEnabled) {
           const element = node as Element;
           const paragraphId = `${postId}-paragraph-${paragraphIndex}`;
           const currentIndex = paragraphIndex;
@@ -91,7 +93,7 @@ export default function PostContentClient({
         return undefined;
       },
     });
-  }, [coAuthorUserId, htmlContent, postId]);
+  }, [coAuthorUserId, htmlContent, paragraphCommentsEnabled, postId]);
 
   return (
     <article className="flex flex-col gap-2">

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Date } from "@components/date";
 import ShareButton from "@components/ShareButton";
 import AudioPlayer from "@components/AudioPlayer";
+import parse, {
+  DOMNode,
+  Element,
+  attributesToProps,
+  domToReact,
+} from "html-react-parser";
+import ParagraphCommentWidget from "@components/paragraph-comments/ParagraphCommentWidget";
 
 type PostContentClientProps = {
   postId: string;
@@ -12,6 +19,7 @@ type PostContentClientProps = {
   initialViews: number;
   audioUrl?: string;
   readingTime: string;
+  coAuthorUserId?: string | null;
 };
 
 export default function PostContentClient({
@@ -21,6 +29,7 @@ export default function PostContentClient({
   initialViews,
   audioUrl,
   readingTime,
+  coAuthorUserId,
 }: PostContentClientProps) {
   const [views, setViews] = useState(initialViews);
 
@@ -49,6 +58,41 @@ export default function PostContentClient({
     };
   }, [postId]);
 
+  const parsedContent = useMemo(() => {
+    if (!htmlContent) {
+      return <p>Conteúdo não disponível.</p>;
+    }
+
+    let paragraphIndex = 0;
+
+    return parse(htmlContent, {
+      replace: (node: DOMNode) => {
+        if (node.type === "tag" && node.name === "p") {
+          const element = node as Element;
+          const paragraphId = `${postId}-paragraph-${paragraphIndex}`;
+          const currentIndex = paragraphIndex;
+          paragraphIndex += 1;
+
+          const paragraphProps = attributesToProps(element.attribs ?? {});
+
+          return (
+            <ParagraphCommentWidget
+              key={paragraphId}
+              postId={postId}
+              paragraphId={paragraphId}
+              paragraphIndex={currentIndex}
+              coAuthorUserId={coAuthorUserId}
+              paragraphProps={paragraphProps}
+            >
+              {domToReact((element.children ?? []) as DOMNode[])}
+            </ParagraphCommentWidget>
+          );
+        }
+        return undefined;
+      },
+    });
+  }, [coAuthorUserId, htmlContent, postId]);
+
   return (
     <article className="flex flex-col gap-2">
       <div className="mb-2 flex-1">
@@ -66,12 +110,9 @@ export default function PostContentClient({
 
       {audioUrl && <AudioPlayer audioUrl={audioUrl} />}
 
-      <div
-        className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs"
-        dangerouslySetInnerHTML={{
-          __html: htmlContent || "<p>Conteúdo não disponível.</p>",
-        }}
-      />
+      <div className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs">
+        {parsedContent}
+      </div>
 
       {/* <Chatbot htmlContent={htmlContent} /> */}
     </article>

--- a/src/app/staff/[...action]/route.ts
+++ b/src/app/staff/[...action]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../lib/mongo"; // Conexão com o MongoDB
+import { resolveAdminStatus } from "../../../lib/admin";
 
 // Tipos para os dados de entrada
 type DeletePostBody = {
@@ -16,10 +16,10 @@ export async function POST(
   const [action] = resolvedParams.action || []; // Captura a primeira parte do wildcard (ex.: "deletePost")
 
   // Autentica o usuário
-  const { sessionClaims } = await auth();
+  const { isAdmin } = await resolveAdminStatus();
 
   // Verifica se o usuário é um admin
-  if (sessionClaims?.metadata?.role !== "admin") {
+  if (!isAdmin) {
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,98 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+import type { User } from "@clerk/backend";
+
+import { getClerkServerClient } from "./clerk-server";
+
+type SessionClaimsLike = Record<string, unknown> | null | undefined;
+
+function hasAdminRole(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  const role = (metadata as Record<string, unknown>).role;
+  return role === "admin";
+}
+
+export function claimsContainAdmin(sessionClaims: SessionClaimsLike): boolean {
+  if (!sessionClaims) {
+    return false;
+  }
+  return (
+    hasAdminRole((sessionClaims as any).metadata) ||
+    hasAdminRole((sessionClaims as any).publicMetadata) ||
+    hasAdminRole((sessionClaims as any).privateMetadata)
+  );
+}
+
+export function userContainsAdminRole(user: Pick<User, "publicMetadata" | "privateMetadata" | "unsafeMetadata"> | null | undefined): boolean {
+  if (!user) {
+    return false;
+  }
+  return (
+    hasAdminRole(user.publicMetadata) ||
+    hasAdminRole(user.privateMetadata) ||
+    hasAdminRole(user.unsafeMetadata)
+  );
+}
+
+export type AdminResolution = {
+  isAdmin: boolean;
+  userId: string | null;
+};
+
+type AdminResolutionOptions = {
+  sessionClaims?: SessionClaimsLike;
+  userId?: string | null | undefined;
+};
+
+export async function resolveAdminStatus(
+  options: AdminResolutionOptions = {}
+): Promise<AdminResolution> {
+  let providedSessionClaims = options.sessionClaims;
+  let providedUserId = options.userId ?? null;
+
+  if (!providedSessionClaims) {
+    const { sessionClaims, userId } = await auth();
+    providedSessionClaims = sessionClaims;
+    if (!providedUserId && userId) {
+      providedUserId = userId;
+    }
+  }
+
+  if (claimsContainAdmin(providedSessionClaims)) {
+    return { isAdmin: true, userId: providedUserId ?? null };
+  }
+
+  let user = null;
+  try {
+    user = await currentUser();
+    if (user && userContainsAdminRole(user)) {
+      return { isAdmin: true, userId: user.id ?? providedUserId ?? null };
+    }
+  } catch (error) {
+    // ignore and try fallback
+  }
+
+  const finalUserId = user?.id ?? providedUserId;
+
+  if (finalUserId) {
+    try {
+      const client = await getClerkServerClient();
+      const fallbackUser = await client.users.getUser(finalUserId);
+      if (userContainsAdminRole(fallbackUser)) {
+        return { isAdmin: true, userId: finalUserId };
+      }
+    } catch (error) {
+      // ignore, final fallback below
+    }
+  }
+
+  return { isAdmin: false, userId: finalUserId ?? null };
+}
+
+export async function assertAdminAccess(): Promise<void> {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    throw new Error("FORBIDDEN_ADMIN_ONLY");
+  }
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -3,6 +3,10 @@ import type { User } from "@clerk/backend";
 
 import { getClerkServerClient } from "./clerk-server";
 
+function isStaticGenerationEnvironment(): boolean {
+  return process.env.NEXT_PHASE === "phase-production-build";
+}
+
 function isDynamicServerUsageError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -57,6 +61,10 @@ type AdminResolutionOptions = {
 export async function resolveAdminStatus(
   options: AdminResolutionOptions = {}
 ): Promise<AdminResolution> {
+  if (isStaticGenerationEnvironment()) {
+    return { isAdmin: false, userId: null };
+  }
+
   let providedSessionClaims = options.sessionClaims;
   let providedUserId = options.userId ?? null;
 

--- a/src/lib/clerk-server.ts
+++ b/src/lib/clerk-server.ts
@@ -1,0 +1,39 @@
+import { createClerkClient, type ClerkClient } from "@clerk/backend";
+import { clerkClient as runtimeClerkClient } from "@clerk/nextjs/server";
+
+let fallbackClient: ClerkClient | null = null;
+
+async function createFallbackClient(): Promise<ClerkClient> {
+  if (fallbackClient) {
+    return fallbackClient;
+  }
+
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  const publishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+
+  if (!secretKey) {
+    throw new Error("CLERK_SECRET_KEY is not configured and Clerk client is unavailable.");
+  }
+
+  fallbackClient = createClerkClient({
+    secretKey,
+    publishableKey,
+  });
+
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(
+      "Using fallback Clerk client. Ensure middleware is configured so clerkClient() can access request data."
+    );
+  }
+
+  return fallbackClient;
+}
+
+export async function getClerkServerClient(): Promise<ClerkClient> {
+  try {
+    return await runtimeClerkClient();
+  } catch (error) {
+    console.error("Failed to resolve Clerk client from request context. Falling back to secret key.", error);
+    return createFallbackClient();
+  }
+}

--- a/types/paragraph-comments.ts
+++ b/types/paragraph-comments.ts
@@ -1,0 +1,11 @@
+export type ParagraphComment = {
+  _id: string;
+  postId: string;
+  paragraphId: string;
+  userId: string;
+  authorName: string;
+  authorImageUrl: string | null;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};


### PR DESCRIPTION
## Summary
- parse post content into interactive blocks with discreet per-paragraph comment triggers
- add a client widget that lets signed-in readers post and manage comments tied to specific paragraphs while preserving the general thread
- expose API routes and types for storing, listing, and moderating paragraph-scoped comments

## Testing
- npm run build *(fails: missing `MONGODB_URI` / `MONGODB_DB` envs)*

------
https://chatgpt.com/codex/tasks/task_e_68fd149cbecc8322aea3c08a3e55aec0