### PR TITLE
Pass admin status from server to client components

### DIFF
--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -16,6 +16,7 @@ import {
 type CommentProps = {
   postId: string;
   coAuthorUserId?: string;
+  isAdmin: boolean;
 };
 
 const COMMENT_MAX_LENGTH = 120;
@@ -23,7 +24,7 @@ const COOLDOWN_MS = 2500;
 
 const emptyDraft: CommentDraft = { nome: "", comentario: "" };
 
-const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
+const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId, isAdmin }) => {
   const { userId, isLoaded } = useAuth();
   const { user } = useUser();
 
@@ -37,7 +38,6 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
   const [replyDrafts, setReplyDrafts] = useState<Record<string, CommentDraft>>({});
   const [replyStatuses, setReplyStatuses] = useState<Record<string, SubmissionStatus>>({});
   const [replyErrors, setReplyErrors] = useState<Record<string, string | null>>({});
-  const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [isClient, setIsClient] = useState(false);
 
   const pendingRequestRef = useRef<AbortController | null>(null);
@@ -62,20 +62,6 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId }) => {
       }
     }
   }, [isClient, isLoaded, postId, userId]);
-
-  useEffect(() => {
-    const checkAdminStatus = async () => {
-      try {
-        const response = await fetch("/admin/api/check", { method: "GET", headers: { "Content-Type": "application/json" } });
-        if (!response.ok) throw new Error(await response.text());
-        const data = await response.json();
-        setIsAdmin(Boolean(data.isAdmin));
-      } catch {
-        setIsAdmin(false);
-      }
-    };
-    if (isLoaded) checkAdminStatus();
-  }, [isLoaded]);
 
   const fetchComments = useCallback(async () => {
     try {

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -38,6 +38,7 @@ type ParagraphCommentWidgetProps = {
   coAuthorUserId?: string | null;
   paragraphProps?: React.HTMLAttributes<HTMLParagraphElement>;
   children: React.ReactNode;
+  isAdmin: boolean;
 };
 
 export default function ParagraphCommentWidget({
@@ -47,6 +48,7 @@ export default function ParagraphCommentWidget({
   coAuthorUserId,
   paragraphProps,
   children,
+  isAdmin,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const OPEN_EVENT = "paragraph-comments:open";
@@ -59,7 +61,6 @@ export default function ParagraphCommentWidget({
   const [hasLoaded, setHasLoaded] = useState(false);
   const [draft, setDraft] = useState("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
   const [isFeatureBlocked, setIsFeatureBlocked] = useState(false);
   const [queuedExpand, setQueuedExpand] = useState<boolean | null>(null);
 
@@ -197,42 +198,6 @@ export default function ParagraphCommentWidget({
 
     void applyToggle();
   }, [hasLoaded, isLoaded, loadComments, queuedExpand, userId]);
-
-  useEffect(() => {
-    if (!isLoaded || !userId) {
-      setIsAdmin(false);
-      return;
-    }
-
-    let isCancelled = false;
-
-    const checkAdmin = async () => {
-      try {
-        const response = await fetch("/admin/api/check", {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        });
-        if (!response.ok) {
-          throw new Error(await response.text());
-        }
-        const data = (await response.json()) as { isAdmin?: boolean };
-        if (!isCancelled) {
-          setIsAdmin(Boolean(data.isAdmin));
-        }
-      } catch (error) {
-        console.error("Failed to check admin status", error);
-        if (!isCancelled) {
-          setIsAdmin(false);
-        }
-      }
-    };
-
-    checkAdmin();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [isLoaded, userId]);
 
   const submitComment = useCallback(async () => {
     const trimmed = draft.trim();

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -185,11 +185,10 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
-  if ((post as any).hidden === true) {
-    const isAdmin = await resolveIsAdmin();
-    if (!isAdmin) {
-      notFound();
-    }
+  const isAdmin = await resolveIsAdmin();
+
+  if ((post as any).hidden === true && !isAdmin) {
+    notFound();
   }
 
   const title = post.title ?? "";
@@ -254,9 +253,14 @@ export default async function PostPage({ params }: PostPageProps) {
         readingTime={readingTime}
         coAuthorUserId={post.coAuthorUserId ?? null}
         paragraphCommentsEnabled={paragraphCommentsEnabled}
+        isAdmin={isAdmin}
       />
       <BackHome />
-      <Comment postId={post.postId} coAuthorUserId={post.coAuthorUserId ?? undefined} />
+      <Comment
+        postId={post.postId}
+        coAuthorUserId={post.coAuthorUserId ?? undefined}
+        isAdmin={isAdmin}
+      />
     </Layout>
   );
 }

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -21,6 +21,7 @@ type PostContentClientProps = {
   readingTime: string;
   coAuthorUserId?: string | null;
   paragraphCommentsEnabled: boolean;
+  isAdmin: boolean;
 };
 
 export default function PostContentClient({
@@ -32,6 +33,7 @@ export default function PostContentClient({
   readingTime,
   coAuthorUserId,
   paragraphCommentsEnabled,
+  isAdmin,
 }: PostContentClientProps) {
   const [views, setViews] = useState(initialViews);
 
@@ -85,6 +87,7 @@ export default function PostContentClient({
               paragraphIndex={currentIndex}
               coAuthorUserId={coAuthorUserId}
               paragraphProps={paragraphProps}
+              isAdmin={isAdmin}
             >
               {domToReact((element.children ?? []) as DOMNode[])}
             </ParagraphCommentWidget>
@@ -93,7 +96,7 @@ export default function PostContentClient({
         return undefined;
       },
     });
-  }, [coAuthorUserId, htmlContent, paragraphCommentsEnabled, postId]);
+  }, [coAuthorUserId, htmlContent, isAdmin, paragraphCommentsEnabled, postId]);
 
   return (
     <article className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- fetch the admin status on the posts page and pass it through to client components
- update comment components to rely on the server-provided admin flag instead of client-side checks
- ensure paragraph comment widgets receive the admin flag without querying the admin API from the browser

## Testing
- npm run lint *(fails: script not found)*
- npm run build *(fails: missing MongoDB env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68fda54461c8832283d3d0c2c4ca6521