### PR TITLE
Optimize paragraph comments responsiveness and post header media

### DIFF
--- a/components/PostHeader.tsx
+++ b/components/PostHeader.tsx
@@ -12,16 +12,23 @@ type PostHeaderProps = {
 };
 
 export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostHeaderProps) {
-  console.log("Cape value in PostHeader:", cape); // Debug para verificar o valor de cape
-  
   const secondaryImage = coAuthorImageUrl || friendImage || undefined;
 
   return (
     <div className="w-full relative">
       {cape && (
-        <div className="w-full relative">
-          <img src={cape} alt="Banner Principal" className="banner w-full h-auto" />
-          <div className="absolute inset-0">
+        <div className="w-full relative overflow-hidden">
+          <div className="relative w-full min-h-[220px] sm:min-h-[320px] lg:min-h-[420px]">
+            <Image
+              src={cape}
+              alt="Banner Principal"
+              fill
+              priority
+              sizes="100vw"
+              className="banner object-cover"
+            />
+          </div>
+          <div className="pointer-events-none absolute inset-0">
             <div className="absolute top-0 left-0 w-full h-[50%] bg-gradient-to-b from-[#040404] via-[#040404]/80 to-transparent"></div>
             <div className="absolute bottom-0 left-0 w-full h-[50%] bg-gradient-to-t from-[#040404] via-[#040404]/80 to-transparent"></div>
           </div>
@@ -40,7 +47,6 @@ export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostH
               {secondaryImage && (
                 <Link href="/">
                   <Image
-                    priority
                     src={secondaryImage}
                     className="foto-post hover:z-30 transition-all"
                     height={56}
@@ -70,7 +76,6 @@ export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostH
             {secondaryImage && (
               <Link href="/">
                 <Image
-                  priority
                   src={secondaryImage}
                   className="rounded-full brightness-125 foto"
                   height={148}

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -39,6 +39,7 @@ type ParagraphCommentWidgetProps = {
   paragraphProps?: React.HTMLAttributes<HTMLParagraphElement>;
   children: React.ReactNode;
   isAdmin: boolean;
+  isMobile: boolean;
 };
 
 export default function ParagraphCommentWidget({
@@ -49,6 +50,7 @@ export default function ParagraphCommentWidget({
   paragraphProps,
   children,
   isAdmin,
+  isMobile,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const OPEN_EVENT = "paragraph-comments:open";
@@ -63,21 +65,6 @@ export default function ParagraphCommentWidget({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isFeatureBlocked, setIsFeatureBlocked] = useState(false);
   const [queuedExpand, setQueuedExpand] = useState<boolean | null>(null);
-
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const checkIsMobile = () => {
-      if (typeof window === "undefined") {
-        setIsMobile(false);
-        return;
-      }
-      setIsMobile(window.innerWidth < 768);
-    };
-    checkIsMobile();
-    window.addEventListener("resize", checkIsMobile);
-    return () => window.removeEventListener("resize", checkIsMobile);
-  }, []);
 
   const loadComments = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- add a shared viewport context in PostContentClient and pass isMobile into ParagraphCommentWidget
- remove the per-widget resize listener by consuming the shared isMobile flag
- render the post header cover with next/image and adjust avatar loading priorities

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68fdb05cd93c83229473796a619bd2cc