### PR TITLE
Create dynamic sitemap and robots metadata routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+import { BASE_URL } from "../lib/base-url";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin"],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /private/
-Allow: /
-Sitemap: https://blog-roan-nu.vercel.app/sitemap

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,41 @@
+import type { MetadataRoute } from "next";
+
+import { BASE_URL } from "../lib/base-url";
+import { getMongoDb } from "../lib/mongo";
+
+export const revalidate = 60;
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const db = await getMongoDb();
+  const postsCollection = db.collection<{ postId: string; date?: Date | string }>("posts");
+
+  const posts = await postsCollection
+    .find({ hidden: { $ne: true } }, { projection: { _id: 0, postId: 1, date: 1 } })
+    .sort({ date: -1 })
+    .toArray();
+
+  const fallbackDate = new Date();
+
+  const postEntries = posts
+    .filter((post) => Boolean(post.postId))
+    .map((post) => {
+      const { postId, date } = post;
+      const lastModifiedValue = date ? new Date(date) : fallbackDate;
+
+      return {
+        url: `${BASE_URL}/posts/${postId}`,
+        lastModified: Number.isNaN(lastModifiedValue.getTime()) ? fallbackDate : lastModifiedValue,
+        priority: 0.8,
+      } satisfies MetadataRoute.Sitemap[number];
+    });
+
+  const staticEntries: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: fallbackDate,
+      priority: 1,
+    },
+  ];
+
+  return [...staticEntries, ...postEntries];
+}

--- a/src/lib/base-url.ts
+++ b/src/lib/base-url.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://domenyk.com";


### PR DESCRIPTION
## Summary
- add a dynamic sitemap route that pulls published posts from MongoDB and includes static URLs
- replace the static robots.txt with a metadata route that references the dynamic sitemap
- centralize the site base URL so both routes build absolute links consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fdc56bc3888322aea2a1bde790d622