### PR TITLE
Simplify post view endpoint payload

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { clientPromise } from "../../../../lib/mongo";
-import { remark } from "remark";
-import html from "remark-html";
 import { resolveAdminStatus } from "../../../../lib/admin";
 
 async function resolveIsAdminFromRequest(): Promise<boolean> {
@@ -44,12 +42,6 @@ export async function GET(
       return NextResponse.json({ error: "Post not found" }, { status: 404 });
     }
 
-    let htmlContent = post.htmlContent;
-    if (htmlContent) {
-      const processedContent = await remark().use(html).process(htmlContent);
-      htmlContent = processedContent.toString();
-    }
-
     // Increment views and set cookie, similar to Pages Router implementation
     const cookieName = `viewed_${id}`;
     const viewedCookie = req.headers
@@ -63,17 +55,7 @@ export async function GET(
       views += 1;
 
       const response = NextResponse.json(
-        {
-          postId: post.postId,
-          date: post.date,
-          title: post.title,
-          htmlContent,
-          views,
-          audioUrl: post.audioUrl,
-          cape: post.cape,
-          friendImage: post.friendImage,
-          coAuthorUserId: (post as any).coAuthorUserId ?? null,
-        },
+        { postId: post.postId, views },
         { status: 200 }
       );
       response.headers.set(
@@ -83,17 +65,7 @@ export async function GET(
       return response;
     }
 
-    const postData = {
-      postId: post.postId,
-      date: post.date,
-      title: post.title,
-      htmlContent,
-      views,
-      audioUrl: post.audioUrl,
-      cape: post.cape,
-      friendImage: post.friendImage,
-      coAuthorUserId: (post as any).coAuthorUserId ?? null,
-    };
+    const postData = { postId: post.postId, views };
 
     console.log("Post data from API for postId:", id, postData);
 

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -80,9 +80,9 @@ export default function PostContentClient({
         if (!response.ok) {
           return;
         }
-        const data = await response.json();
-        if (!canceled && typeof data.views === "number") {
-          setViews(data.views);
+        const { views } = await response.json();
+        if (!canceled && typeof views === "number") {
+          setViews(views);
         }
       } catch (error) {
         console.error("Failed to refresh post views", error);


### PR DESCRIPTION
## Summary
- remove server-side remark processing from the post detail API route and return a minimal payload for view tracking
- keep cookie-based view tracking while updating the client hook to read the slimmed API response

## Testing
- CI=1 npm run build *(fails: missing MongoDB environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68fe39e1aa64832288a9596df5d1af43