### PR TITLE
Remove backdrop blur from paragraph comment modal overlay

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -610,7 +610,7 @@ export default function ParagraphCommentWidget({
       {showLoginPrompt && (
         <div className="fixed inset-0 z-50 flex items-end justify-end p-4 sm:p-8">
           <div
-            className="absolute inset-0 bg-black/20 backdrop-blur-sm"
+            className="absolute inset-0 bg-black/20"
             aria-hidden="true"
             onClick={() => closeLoginPrompt({ clearQueuedExpand: true })}
           />


### PR DESCRIPTION
## Summary
- remove the backdrop blur utility from the paragraph comment modal overlay to eliminate the background blur effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe6529767883228d465409cde668d5