### PR TITLE
Add desktop post minimap navigation

### DIFF
--- a/components/PostMinimap.tsx
+++ b/components/PostMinimap.tsx
@@ -120,7 +120,9 @@ export default function PostMinimap() {
   }
 
   return (
-    <aside className="hidden md:flex md:flex-col md:w-60 md:pl-4 lg:pl-6 sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto text-sm text-zinc-600 dark:text-zinc-400">
+    <aside
+      className="hidden md:flex md:flex-col fixed top-24 right-4 w-60 max-h-[calc(100vh-6rem)] overflow-y-auto rounded-lg border border-zinc-200/80 bg-white/70 p-3 text-sm text-zinc-600 shadow-lg shadow-zinc-900/5 backdrop-blur dark:border-zinc-700/60 dark:bg-zinc-900/60 dark:text-zinc-400"
+    >
       <span className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500 mb-3">
         Neste artigo
       </span>

--- a/components/PostMinimap.tsx
+++ b/components/PostMinimap.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useIsMobile } from "src/app/posts/[id]/post-content-client";
+import { useHeadingsMap } from "@components/useHeadingsMap";
+
+export default function PostMinimap() {
+  const isMobile = useIsMobile();
+  const headings = useHeadingsMap({ enabled: !isMobile });
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [clickedId, setClickedId] = useState<string | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener?.("change", updatePreference);
+    mediaQuery.addListener?.(updatePreference);
+
+    return () => {
+      mediaQuery.removeEventListener?.("change", updatePreference);
+      mediaQuery.removeListener?.(updatePreference);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) {
+      setActiveId(null);
+      return;
+    }
+
+    if (headings.length === 0 || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort(
+            (a, b) =>
+              a.target.getBoundingClientRect().top - b.target.getBoundingClientRect().top,
+          );
+
+        if (visible.length > 0) {
+          const target = visible[0].target as HTMLHeadingElement;
+          const matched = headings.find((heading) => heading.element === target);
+          if (matched) {
+            setActiveId((current) => (current === matched.id ? current : matched.id));
+          }
+          return;
+        }
+
+        let fallbackId: string | null = null;
+        for (const heading of headings) {
+          const top = heading.element.getBoundingClientRect().top;
+          if (top <= 24) {
+            fallbackId = heading.id;
+            continue;
+          }
+          if (fallbackId === null) {
+            fallbackId = heading.id;
+          }
+          break;
+        }
+
+        if (fallbackId) {
+          setActiveId((current) => (current === fallbackId ? current : fallbackId));
+        }
+      },
+      {
+        rootMargin: "-30% 0px -60% 0px",
+        threshold: [0, 0.25, 1],
+      },
+    );
+
+    headings.forEach((heading) => observer.observe(heading.element));
+
+    return () => {
+      headings.forEach((heading) => observer.unobserve(heading.element));
+      observer.disconnect();
+    };
+  }, [headings, isMobile]);
+
+  useEffect(() => {
+    if (isMobile || headings.length === 0) {
+      return;
+    }
+
+    setActiveId((current) => current ?? headings[0]?.id ?? null);
+  }, [headings, isMobile]);
+
+  useEffect(() => {
+    if (clickedId === null || prefersReducedMotion) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setClickedId(null);
+    }, 220);
+
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [clickedId, prefersReducedMotion]);
+
+  const transitionClasses = useMemo(
+    () => (prefersReducedMotion ? "" : "transition-all duration-200 ease-in-out"),
+    [prefersReducedMotion],
+  );
+
+  if (isMobile || headings.length === 0) {
+    return null;
+  }
+
+  return (
+    <aside className="hidden md:flex md:flex-col md:w-60 md:pl-4 lg:pl-6 sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto text-sm text-zinc-600 dark:text-zinc-400">
+      <span className="text-xs uppercase tracking-wide text-zinc-400 dark:text-zinc-500 mb-3">
+        Neste artigo
+      </span>
+      <nav className="flex flex-col gap-1.5" aria-label="Mapa do post">
+        {headings.map((heading) => {
+          const isActive = heading.id === activeId;
+          const isClicked = heading.id === clickedId && !prefersReducedMotion;
+
+          return (
+            <button
+              key={heading.id}
+              type="button"
+              title={heading.text}
+              className={[
+                "text-left w-full rounded-md px-3 py-1.5 text-ellipsis whitespace-nowrap overflow-hidden",
+                transitionClasses,
+                isActive
+                  ? "bg-zinc-200/70 text-zinc-900 dark:bg-zinc-800/60 dark:text-zinc-100"
+                  : "hover:text-zinc-900 hover:bg-zinc-100/70 dark:hover:text-zinc-100 dark:hover:bg-zinc-800/40",
+                !prefersReducedMotion ? "hover:text-[0.95rem]" : "",
+                isClicked ? "ring-2 ring-zinc-300 dark:ring-zinc-600 scale-[1.02]" : "",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 dark:focus-visible:ring-zinc-500",
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              aria-current={isActive ? "true" : undefined}
+              onMouseEnter={() => {
+                if (prefersReducedMotion) {
+                  return;
+                }
+                setClickedId(null);
+              }}
+              onClick={() => {
+                const behavior = prefersReducedMotion ? "auto" : "smooth";
+                heading.element.scrollIntoView({ behavior, block: "start" });
+                if (!prefersReducedMotion) {
+                  setClickedId(heading.id);
+                }
+              }}
+            >
+              {heading.text}
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/components/useHeadingsMap.ts
+++ b/components/useHeadingsMap.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+
+export type HeadingEntry = {
+  id: string;
+  text: string;
+  level: number;
+  element: HTMLHeadingElement;
+};
+
+type UseHeadingsMapOptions = {
+  enabled?: boolean;
+  dependencies?: ReadonlyArray<unknown>;
+};
+
+function slugifyHeading(text: string): string {
+  const normalized = text
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+
+  const cleaned = normalized.replace(/[^a-z0-9\s-]/g, " ");
+  const collapsed = cleaned.trim().replace(/\s+/g, "-");
+
+  return collapsed.length > 0 ? collapsed : "heading";
+}
+
+export function useHeadingsMap({
+  enabled = true,
+  dependencies = [],
+}: UseHeadingsMapOptions = {}): HeadingEntry[] {
+  const [headings, setHeadings] = useState<HeadingEntry[]>([]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setHeadings([]);
+      return;
+    }
+
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const nodes = Array.from(document.querySelectorAll("h4"));
+    const slugCounts = new Map<string, number>();
+
+    const nextHeadings = nodes.map((node) => {
+      const element = node as HTMLHeadingElement;
+      const text = element.textContent?.trim() ?? "";
+
+      let identifier = element.id?.trim() ?? "";
+      if (!identifier) {
+        const base = slugifyHeading(text);
+        const currentCount = slugCounts.get(base) ?? 0;
+        slugCounts.set(base, currentCount + 1);
+        identifier = currentCount === 0 ? base : `${base}-${currentCount}`;
+      }
+
+      return {
+        id: identifier,
+        text,
+        level: 4,
+        element,
+      } satisfies HeadingEntry;
+    });
+
+    setHeadings(nextHeadings);
+  }, [enabled, ...dependencies]);
+
+  return headings;
+}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -171,7 +171,7 @@ export default function PostContentClient({
 
   return (
     <IsMobileContext.Provider value={isMobile}>
-      <div className="relative flex flex-col gap-6 md:pr-64 lg:pr-72">
+      <div className="relative flex flex-col gap-6">
         <article className="flex flex-col gap-6">
           <div className="flex flex-col gap-2">
             <div className="flex gap-2 items-center">
@@ -194,8 +194,8 @@ export default function PostContentClient({
 
           {/* <Chatbot htmlContent={htmlContent} /> */}
         </article>
-        <PostMinimap />
       </div>
+      <PostMinimap />
     </IsMobileContext.Provider>
   );
 }

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -171,8 +171,8 @@ export default function PostContentClient({
 
   return (
     <IsMobileContext.Provider value={isMobile}>
-      <article className="flex flex-col gap-6 md:flex-row md:items-start">
-        <div className="flex-1 flex flex-col gap-4">
+      <div className="relative flex flex-col gap-6 md:pr-64 lg:pr-72">
+        <article className="flex flex-col gap-6">
           <div className="flex flex-col gap-2">
             <div className="flex gap-2 items-center">
               <Date dateString={date} />
@@ -193,10 +193,9 @@ export default function PostContentClient({
           </div>
 
           {/* <Chatbot htmlContent={htmlContent} /> */}
-        </div>
-
+        </article>
         <PostMinimap />
-      </article>
+      </div>
     </IsMobileContext.Provider>
   );
 }

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -20,6 +20,7 @@ import parse, {
 import ParagraphCommentWidget from "@components/paragraph-comments/ParagraphCommentWidget";
 import PostReference from "@components/PostReference";
 import AutorReference from "@components/AutorReference";
+import PostMinimap from "@components/PostMinimap";
 
 const IsMobileContext = createContext<boolean | null>(null);
 
@@ -170,27 +171,31 @@ export default function PostContentClient({
 
   return (
     <IsMobileContext.Provider value={isMobile}>
-      <article className="flex flex-col gap-2">
-        <div className="mb-2 flex-1">
-          <div className="flex gap-2 items-center">
-            <Date dateString={date} />
-            <div className="flex gap-2 text-sm text-zinc-500">
-              <span>• {readingTime}</span>
-              <span>{views} views</span>
+      <article className="flex flex-col gap-6 md:flex-row md:items-start">
+        <div className="flex-1 flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-center">
+              <Date dateString={date} />
+              <div className="flex gap-2 text-sm text-zinc-500">
+                <span>• {readingTime}</span>
+                <span>{views} views</span>
+              </div>
+            </div>
+            <div>
+              <ShareButton id={postId} />
             </div>
           </div>
-          <div className="">
-            <ShareButton id={postId} />
+
+          {audioUrl && <AudioPlayer audioUrl={audioUrl} />}
+
+          <div className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs">
+            {parsedContent}
           </div>
+
+          {/* <Chatbot htmlContent={htmlContent} /> */}
         </div>
 
-        {audioUrl && <AudioPlayer audioUrl={audioUrl} />}
-
-        <div className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs">
-          {parsedContent}
-        </div>
-
-        {/* <Chatbot htmlContent={htmlContent} /> */}
+        <PostMinimap />
       </article>
     </IsMobileContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add a reusable `useHeadingsMap` hook that collects rendered `h4` elements with generated slugs when needed
- build a desktop-only `PostMinimap` component with intersection tracking, smooth scrolling, and reduced-motion safeguards
- integrate the minimap into the post client layout so it only renders on larger breakpoints

## Testing
- npm run build *(fails: missing MONGODB_URI and MONGODB_DB)*

------
https://chatgpt.com/codex/tasks/task_e_69018f4558c48322812b9f6d225d3c3c