### PR TITLE
Create reusable comment avatar component

### DIFF
--- a/components/CommentAvatar.tsx
+++ b/components/CommentAvatar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+
+import { generateIdenticon } from "./comments/utils";
+
+type CommentAvatarProps = {
+  imageUrl?: string | null;
+  name: string;
+  ipHash?: string;
+  size?: number;
+  className?: string;
+};
+
+const DEFAULT_BLUR_DATA_URL =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMicgaGVpZ2h0PScyJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScyJyBoZWlnaHQ9JzInIGZpbGw9JyNFMEUwRTAnIC8+PC9zdmc+";
+
+export default function CommentAvatar({
+  imageUrl,
+  name,
+  ipHash,
+  size = 40,
+  className,
+}: CommentAvatarProps) {
+  const fallbackSrc = useMemo(
+    () => generateIdenticon(name, ipHash ?? ""),
+    [name, ipHash]
+  );
+
+  const [hasError, setHasError] = useState(false);
+  const [currentSrc, setCurrentSrc] = useState<string>(
+    imageUrl ?? fallbackSrc
+  );
+
+  useEffect(() => {
+    setHasError(false);
+    setCurrentSrc(imageUrl ?? fallbackSrc);
+  }, [imageUrl, fallbackSrc]);
+
+  return (
+    <Image
+      src={currentSrc}
+      alt={`Avatar de ${name}`}
+      width={size}
+      height={size}
+      className={`rounded-full object-cover ${className ?? ""}`.trim()}
+      placeholder="blur"
+      blurDataURL={DEFAULT_BLUR_DATA_URL}
+      onError={() => {
+        if (hasError) {
+          return;
+        }
+        console.debug("CommentAvatar: fallback to identicon", {
+          name,
+          ipHash,
+          imageUrl,
+        });
+        setHasError(true);
+        setCurrentSrc(fallbackSrc);
+      }}
+    />
+  );
+}

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -1,6 +1,7 @@
 ﻿import React, { useState, useEffect } from "react";
 import { CheckBadgeIcon, TrashIcon } from "@heroicons/react/24/solid";
 
+import CommentAvatar from "../CommentAvatar";
 import ReplyForm from "./ReplyForm";
 import { STANDARD_COMMENT_MAX_LENGTH } from "./lengthUtils";
 import {
@@ -11,7 +12,6 @@ import {
 } from "./types";
 import {
   extractDisplayName,
-  generateIdenticon,
   sanitizeCommentHtml,
   formatDate,
 } from "./utils";
@@ -59,9 +59,6 @@ const CommentItem: React.FC<CommentItemProps> = ({
     return () => document.removeEventListener("keydown", onKey);
   }, [showDeleteModal]);
   const displayName = extractDisplayName(comment);
-  const avatarUrl = isAuthComment(comment) && comment.hasImage
-    ? comment.imageURL
-    : generateIdenticon(displayName, comment.ip);
 
   const handleSubmit = () => {
     onReplySubmit(replyDraft);
@@ -76,10 +73,12 @@ const CommentItem: React.FC<CommentItemProps> = ({
       }`}
     >
       <div className="flex items-start gap-3">
-        <img
-          src={avatarUrl}
-          alt={`${displayName} avatar`}
-          className="h-8 w-8 rounded-full max-sm:w-6 object-cover icon"
+        <CommentAvatar
+          imageUrl={isAuthComment(comment) && comment.hasImage ? comment.imageURL : null}
+          name={displayName}
+          ipHash={comment.ip}
+          size={32}
+          className="h-8 w-8 max-sm:h-6 max-sm:w-6 icon"
         />
         <div className="flex-1 min-w-0 space-y-3">
           <div className="flex flex-wrap items-center gap-3 text-sm">

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -8,6 +8,7 @@ import {
   buildLengthErrorMessage,
   useCommentLength,
 } from "@components/comments/lengthUtils";
+import CommentAvatar from "@components/CommentAvatar";
 import { sanitizeCommentHtml } from "@components/comments/utils";
 import { UPPERCASE_MAX_RATIO, getUppercaseState, buildUppercaseErrorMessage } from "@components/comments/uppercaseUtils";
 import type { ParagraphComment } from "../../types/paragraph-comments";
@@ -782,18 +783,12 @@ export default function ParagraphCommentWidget({
             ) : (
               formattedComments.map((comment) => (
                 <div key={comment._id} className="flex items-start gap-3">
-                  {comment.authorImageUrl ? (
-                    <img
-                      src={comment.authorImageUrl}
-                      alt={comment.authorName}
-                      className="h-8 w-8 rounded-full object-cover icon"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-zinc-200 text-sm font-semibold text-zinc-600 dark:bg-zinc-700 dark:text-zinc-200">
-                      {comment.authorName.charAt(0).toUpperCase()}
-                    </div>
-                  )}
+                  <CommentAvatar
+                    imageUrl={comment.authorImageUrl}
+                    name={comment.authorName}
+                    size={32}
+                    className="h-8 w-8 icon"
+                  />
                   <div className="flex-1 min-w-0 rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm text-zinc-700 shadow-sm dark:border-zinc-700 dark:bg-zinc-800/80 dark:text-zinc-100">
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add a shared CommentAvatar component that uses Next Image with identicon fallback logging errors
- update comment item and paragraph comment widget to render avatars through the new component

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_6901a2552bdc83229936f53d37a36c12