### PR TITLE
Improve social metadata for posts and home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ export const dynamic = "force-dynamic";
 
 const PAGE_SIZE = 10;
 const BASE_URL = "https://domenyk.com";
+const DEFAULT_SOCIAL_IMAGE = `${BASE_URL}/images/profile.jpg`;
 
 function parsePage(p: unknown): number {
   const num = typeof p === "string" ? parseInt(p, 10) : 1;
@@ -49,12 +50,22 @@ export async function generateMetadata({
       title,
       description,
       url: canonical,
+      type: "website",
+      siteName: "Domenyk",
+      locale: "pt_BR",
+      images: [
+        {
+          url: DEFAULT_SOCIAL_IMAGE,
+          alt: "Retrato de Domenyk",
+        },
+      ],
     },
     twitter: {
       site: "@l31t1",
       card: "summary_large_image",
       title,
       description,
+      images: [DEFAULT_SOCIAL_IMAGE],
     },
     // Note: Next Metadata API does not natively support link rel=prev/next.
   };

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -31,6 +31,7 @@ type PostDocument = {
   coAuthorUserId?: string | null;
   hidden?: boolean;
   paragraphCommentsEnabled?: boolean;
+  updatedAt?: string | Date;
 };
 
 type PostPageProps = {
@@ -130,7 +131,15 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 
   const title = post.title ?? "";
   const date = normalizeDate(post.date);
-  const url = `https://domenyk.com/posts/${id}`;
+  const BASE_URL = "https://domenyk.com";
+  const FALLBACK_IMAGE_PATH = "/images/profile.jpg";
+  const cape = typeof post.cape === "string" ? post.cape.trim() : "";
+  const imageSource = cape || FALLBACK_IMAGE_PATH;
+  const imageUrl = new URL(imageSource, BASE_URL).toString();
+  const url = `${BASE_URL}/posts/${id}`;
+  const updatedAt = normalizeDate(post.updatedAt);
+  const publishedTime = date || undefined;
+  const modifiedTime = updatedAt || undefined;
 
   return {
     title: `${title} - Blog`,
@@ -139,14 +148,24 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
       title,
       description: title,
       url,
+      type: "article",
+      images: [
+        {
+          url: imageUrl,
+          alt: title,
+        },
+      ],
+      publishedTime,
+      modifiedTime,
     },
     twitter: {
       site: "@l31t1",
       card: "summary_large_image",
+      images: [imageUrl],
     },
     other: {
-      "article:published_time": date,
-      "article:modified_time": date,
+      "article:published_time": publishedTime,
+      "article:modified_time": modifiedTime ?? publishedTime,
     },
   };
 }


### PR DESCRIPTION
## Summary
- derive an absolute social image for posts with a fallback and reuse it for Open Graph/Twitter metadata
- mark posts as Open Graph articles and surface publish/modified timestamps when available
- add default social image metadata and site information to the home page Open Graph config

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_69025b15a40c832285a83d99fd5f2f12