### PR TITLE
Redesign site interface with austere layout

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -1,5 +1,4 @@
-﻿import Link from "next/link";
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
+import Link from "next/link";
 import { buildUrl } from "../src/lib/url";
 
 export default function Pagination({
@@ -23,31 +22,32 @@ export default function Pagination({
     ? buildUrl(pathname, searchParams, { page: page + 1 })
     : undefined;
 
-  const nextNumber = nextEnabled ? page + 1 : undefined;
-
   return (
-    <div className="flex items-center justify-center gap-3 mt-8">
-      <Link aria-disabled={!prevEnabled} className={`rounded-full px-4 py-2 border shadow-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200 ease-in-out ${!prevEnabled ? "pointer-events-none" : ""}`} href={prevHref || "#"} prefetch={false} tabIndex={prevEnabled ? 0 : -1}><ChevronLeftIcon className="h-4 w-4" /></Link>
-      <span className="text-sm md:text-base font-medium">
-        {page} / {nextEnabled ? page + 1 : "—"}
-      </span>
-      <Link aria-disabled={!nextEnabled} className={`rounded-full px-4 py-2 border shadow-sm hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all duration-200 ease-in-out ${!nextEnabled ? "pointer-events-none" : ""}`} href={nextHref || "#"} prefetch={false} tabIndex={nextEnabled ? 0 : -1}><ChevronRightIcon className="h-4 w-4" /></Link>
-    </div>
+    <nav className="mt-12 flex items-center justify-between border-t border-neutral-900 pt-6 text-[11px] uppercase tracking-[0.35em] text-neutral-600">
+      <Link
+        aria-disabled={!prevEnabled}
+        className={`border border-neutral-800 px-3 py-2 transition-colors hover:border-neutral-500 hover:text-neutral-100 ${
+          prevEnabled ? "" : "pointer-events-none opacity-30"
+        }`}
+        href={prevHref || "#"}
+        prefetch={false}
+        tabIndex={prevEnabled ? 0 : -1}
+      >
+        anterior
+      </Link>
+      <span className="text-neutral-400">página {page.toString().padStart(2, "0")}</span>
+      <Link
+        aria-disabled={!nextEnabled}
+        className={`border border-neutral-800 px-3 py-2 transition-colors hover:border-neutral-500 hover:text-neutral-100 ${
+          nextEnabled ? "" : "pointer-events-none opacity-30"
+        }`}
+        href={nextHref || "#"}
+        prefetch={false}
+        tabIndex={nextEnabled ? 0 : -1}
+      >
+        próxima
+      </Link>
+    </nav>
   );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -36,23 +36,18 @@ export default function SearchBar({ onSearch, initialQuery = "", rightSlot }: Se
   };
 
   return (
-    <form onSubmit={handleSubmit} className="relative">
-      <div className="flex items-center gap-2 bg-zinc-800 border border-zinc-700 rounded px-2 py-1 w-[30vw] min-w-[220px] sm:w-1/3 md:w-[360px]">
-        <MagnifyingGlassIcon className="w-4 h-4" />
+    <form onSubmit={handleSubmit} className="w-full max-w-xl">
+      <div className="group flex w-full items-center gap-3 border-b border-neutral-800 pb-3 text-sm uppercase tracking-[0.2em] text-neutral-500 transition-colors focus-within:border-neutral-400 focus-within:text-neutral-300">
+        <MagnifyingGlassIcon className="h-4 w-4" />
         <input
           ref={inputRef}
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Pesquisar posts"
-          className="bg-transparent outline-none placeholder-zinc-400 flex-1 min-w-0"
+          placeholder="Buscar"
+          className="flex-1 min-w-0 bg-transparent text-base font-medium uppercase tracking-[0.25em] text-neutral-200 placeholder:text-neutral-500 focus:outline-none"
         />
-        {rightSlot && (
-          <>
-            <span className="h-4 w-px bg-zinc-500/20" aria-hidden />
-            <div className="flex items-center">{rightSlot}</div>
-          </>
-        )}
+        {rightSlot && <div className="flex items-center gap-2 text-[10px] tracking-[0.4em]">{rightSlot}</div>}
       </div>
     </form>
   );

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -1,26 +1,21 @@
 "use client";
 
-import { useState } from "react";
-import { EllipsisVerticalIcon, XMarkIcon } from "@heroicons/react/20/solid";
-import {
-  useUser,  
-  ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  UserButton, 
-} from "@clerk/nextjs";	
+import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 export default function SettingsMenu() {
 
   return (
-    <div className="">
-                <SignedOut>
-                  <SignInButton />
-                </SignedOut>
-                <SignedIn>
-                  <UserButton />
-                </SignedIn>
+    <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.35em] text-neutral-500">
+      <SignedOut>
+        <SignInButton mode="modal">
+          <button className="border border-neutral-800 px-3 py-2 transition-colors hover:border-neutral-500 hover:text-neutral-100">
+            entrar
+          </button>
+        </SignInButton>
+      </SignedOut>
+      <SignedIn>
+        <UserButton appearance={{ variables: { colorPrimary: "#8b8b8b" } }} />
+      </SignedIn>
     </div>
   );
 }

--- a/components/ThemeSwitcher.tsx
+++ b/components/ThemeSwitcher.tsx
@@ -45,11 +45,15 @@ export default function ThemeSwitcher() {
   };
 
   return (
-    <button className="" onClick={toggleDarkMode}>
+    <button
+      onClick={toggleDarkMode}
+      aria-label="Alternar modo de cor"
+      className="border border-neutral-800 p-2 transition-colors hover:border-neutral-500 hover:text-neutral-100"
+    >
       {darkMode ? (
-        <SunIcon className="svg-icon" width={24} height={24} />
+        <SunIcon className="svg-icon" width={20} height={20} />
       ) : (
-        <MoonIcon className="svg-icon" width={24} height={24} />
+        <MoonIcon className="svg-icon" width={20} height={20} />
       )}
     </button>
   );

--- a/components/date.tsx
+++ b/components/date.tsx
@@ -17,7 +17,7 @@ export function Date({ dateString }: DateProps): JSX.Element {
 
   return (
     <time
-      className="text-secondary text-lg text-zinc-500"
+      className="text-[11px] uppercase tracking-[0.35em] text-neutral-500"
       dateTime={dateString}
     >
       {formattedDate}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import Image from "next/image";
- 
 
 type HeaderProps = {
   home?: boolean;
@@ -11,37 +10,41 @@ type HeaderProps = {
 const name = "Domenyk";
 
 export function Header({ home }: HeaderProps) {
-  
+  const figure = (
+    <div className="overflow-hidden border border-neutral-800 bg-neutral-900 shadow-[0_0_120px_rgba(0,0,0,0.35)]">
+      <Image
+        priority
+        src="/images/profile.jpg"
+        className="h-auto w-full object-cover grayscale-[60%] contrast-125"
+        height={640}
+        width={512}
+        alt={name}
+      />
+    </div>
+  );
 
   return (
-    <header className="flex flex-col gap-4 items-center">
+    <header className="flex flex-col gap-8">
       {home ? (
-        <>
-          <Image
-            priority
-            src="/images/profile.jpg"
-            className="rounded-full brightness-125 foto"
-            height={148}
-            width={148}
-            alt={name}
-          />
-          <strong className="text-3xl">{name}</strong>
-        </>
+        figure
       ) : (
-        <>
-          <Link href="/" legacyBehavior>
-            <Image
-              priority
-              src="/images/profile.jpg"
-              className="rounded-full brightness-125 foto"
-              height={148}
-              width={148}
-              alt={name}
-            />
-          </Link>
-          <strong className="text-3xl">Domenyk</strong>
-        </>
+        <Link href="/" className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500">
+          {figure}
+        </Link>
       )}
+
+      <div className="flex flex-col gap-4">
+        <span className="text-xs uppercase tracking-[0.3em] text-neutral-500">Autor</span>
+        <strong className="text-4xl font-semibold tracking-tight text-neutral-100">{name}</strong>
+        <p className="text-sm leading-6 text-neutral-400">
+          Registro público das leituras, discordâncias e posições que resolvi manter acessíveis.
+        </p>
+        <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.25em] text-neutral-500">
+          <span className="rounded-full border border-neutral-700 px-3 py-1">Análise</span>
+          <span className="rounded-full border border-neutral-700 px-3 py-1">Relato</span>
+          <span className="rounded-full border border-neutral-700 px-3 py-1">Observação</span>
+        </div>
+      </div>
     </header>
   );
 }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -12,14 +12,32 @@ type LayoutProps = {
 
 export function Layout({ home = false, children }: LayoutProps) {
   return (
-    <div className="max-w-xl flex flex-col mx-auto px-4 mb-4">
-      <div className="flex justify-between items-center py-1">
-      <ThemeSwitcher /> {/* Botão de brilho à direita */}
-      <SettingsMenu /> {/* Botão de três pontos à esquerda */}
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 antialiased">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-10 lg:px-12 lg:py-14">
+        <div className="flex flex-col gap-6 border-b border-neutral-800 pb-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex flex-col gap-2 text-neutral-400">
+            <span className="text-xs font-medium uppercase tracking-[0.4em] text-neutral-500">
+              Domenyk.com
+            </span>
+            <span className="text-sm leading-relaxed">
+              Notas públicas, observações e relatórios pessoais publicados sem adornos.
+            </span>
+          </div>
+          <div className="flex items-center gap-3 text-neutral-400">
+            <SettingsMenu />
+            <ThemeSwitcher />
+          </div>
+        </div>
+        <main
+          className={`flex-1 pt-10 ${
+            home
+              ? "lg:grid lg:grid-cols-[minmax(220px,320px)_1fr] lg:items-start lg:gap-16"
+              : "flex flex-col gap-12"
+          }`}
+        >
+          {children}
+        </main>
       </div>
-      <main className={`${home ? "home" : ""} flex flex-col flex-1`}>
-        {children}
-      </main>
     </div>
   );
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,96 +1,69 @@
-/* styles/global.css */
 @import "tailwindcss";
 
 @font-face {
-  font-family: 'PolySans';
-  src: url(./PolySans-Slim.woff2) format('woff2');
+  font-family: "PolySans";
+  src: url(./PolySans-Slim.woff2) format("woff2");
   font-weight: normal;
   font-style: normal;
 }
 
-/* Estilo inicial do body (modo escuro por padrão) */
+:root {
+  color-scheme: dark;
+}
+
 body {
-  font-family: 'PolySans';
-  background-color: #040404; /* Escuro por padrão */
-  color: #f1f1f1; /* Texto claro por padrão */
-  transition: background-color 0.3s, color 0.3s;
+  font-family: "PolySans", "IBM Plex Sans", "Inter", sans-serif;
+  background-color: #050505;
+  color: #e5e5e5;
+  letter-spacing: -0.01em;
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 .light-mode {
-  background-color: #f4f4f4;
-  color: #040404;
-  transition: background-color 0.1s, color 0.1s;
+  background-color: #f5f5f5;
+  color: #161616;
 }
 
 .dark-mode {
-  background-color: #040404;
-  color: #f1f1f1;
-  transition: background-color 0.1s, color 0.1s;
-}
-
-/* Estilo do scrollbar */
-::-webkit-scrollbar {
-  width: 12px;
-}
-
-::-webkit-scrollbar-track {
-  background: #f1f1f1;
-}
-
-::-webkit-scrollbar-thumb {
-  background-color: #888;
-  border-radius: 10px;
-  border: 3px solid #f1f1f1;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background-color: #050505;
+  color: #e5e5e5;
 }
 
 a {
-  color: var(--link-color);
+  color: inherit;
   text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
+  color: #fafafa;
 }
-ul {
-  @apply list-disc ml-10;
-}
-.ml-0 {
-  @apply ml-0;
-}
-.foto {
-  @apply rounded-full w-37 h-37;
-}
-.foto-post {
-  @apply  rounded-full  w-10 h-10;
-}
-.banner {
-  @apply rounded-2xl grayscale-0 w-full h-auto object-scale-down;
-}
-.icon {
-  @apply w-10 h-10 grayscale-0 rounded-full;
-}
-.svg-icon {
-  @apply w-8 h-8 rounded-full;
-}
-.reference {
-  @apply grayscale-0;
-  object-position: 100% 90%;
-}
+
 img {
-  @apply rounded-md grayscale-100 w-full h-full;
+  border-radius: 0;
 }
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.svg-icon {
+  @apply h-6 w-6 text-neutral-400 transition-colors duration-200 hover:text-neutral-200;
+}
+
+h1,
+h2,
+h3,
 h4 {
-  @apply lg:text-3xl max-sm:text-xl font-bold;
+  color: #f8f8f8;
+  font-weight: 500;
+  letter-spacing: -0.015em;
 }
-h6 {
-  @apply text-sm font-extralight bg-zinc-950 px-2 py-1 rounded-md max-w-fit;
-}
-h1 {
-  @apply sm:text-sm md:text-lg;
+
+small {
+  color: #9f9f9f;
 }
 
 

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -1,9 +1,9 @@
-﻿"use client";
+"use client";
 
 import { useRef, useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { TrashIcon, ChevronDownIcon } from "@heroicons/react/24/solid";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import SearchBar from "@components/SearchBar";
 import Pagination from "@components/Pagination";
 import { Date } from "@components/date";
@@ -30,6 +30,7 @@ const SORT_OPTIONS = [
   { label: "Views (menor → maior)", value: { sort: "views" as const, order: "asc" as const } },
   { label: "Views (maior → menor)", value: { sort: "views" as const, order: "desc" as const } },
 ];
+
 export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [postToDelete, setPostToDelete] = useState<string | null>(null);
@@ -127,117 +128,151 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
   };
 
   return (
-    <section className="flex-1 gap-6">
-      <div className="flex items-center flex-wrap mb-6 gap-4">
-        <h1 className="font-bold text-2xl">Blog</h1>
-        <div className="ml-2 sm:ml-4">
+    <section className="flex flex-col gap-12">
+      <div className="flex flex-col gap-6 border-b border-neutral-900 pb-8">
+        <div className="flex flex-col gap-2 text-neutral-400">
+          <span className="text-xs uppercase tracking-[0.35em] text-neutral-500">Sessão ativa</span>
+          <h2 className="text-3xl font-semibold text-neutral-100">Blog</h2>
+          <p className="text-sm leading-6 text-neutral-500">
+            Busque, ordene e percorra os arquivos publicados. Tudo aparece em sequência, sem ornamentos.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
           <SearchBar
             onSearch={onSearch}
             initialQuery={query}
             rightSlot={
               <div className="relative" ref={sortRef}>
                 <button
-                  type="button" aria-label="Ordenar"
+                  type="button"
+                  aria-label="Ordenar"
                   aria-haspopup="listbox"
                   aria-expanded={openSort}
                   onClick={() => setOpenSort((v) => !v)}
-                  className="inline-flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-zinc-700 transition-colors"
+                  className="inline-flex items-center gap-2 border border-neutral-800 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.4em] text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-100"
                 >
-                  <span className="hidden sm:inline whitespace-nowrap">{currentSortLabel}</span>
-                  <ChevronDownIcon className={`h-4 w-4 transition-transform duration-200 ${openSort ? "rotate-180" : "rotate-0"}`} />
+                  <span className="hidden whitespace-nowrap sm:inline">{currentSortLabel}</span>
+                  <ChevronDownIcon
+                    className={`h-4 w-4 transition-transform duration-200 ${openSort ? "-scale-y-100" : "scale-y-100"}`}
+                  />
                 </button>
                 {openSort && (
                   <div
                     role="listbox"
-                    className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-zinc-700 bg-zinc-900 p-2 max-h-[200px] overflow-auto shadow-lg"
+                    className="absolute right-0 z-20 mt-3 w-72 border border-neutral-800 bg-neutral-950 p-2 shadow-[0_24px_70px_rgba(0,0,0,0.65)]"
                   >
-                    {SORT_OPTIONS.map((opt) => {
-                      const key = `${opt.value.sort ?? ""}:${opt.value.order ?? ""}`;
-                      const selected = key === currentSortKey;
-                      return (
-                        <button
-                          key={key}
-                          type="button"
-                          role="option"
-                          aria-selected={selected}
-                          onClick={() => onSelectSort(key)}
-                          className={`w-full text-left px-4 py-2 rounded-md text-sm transition-colors hover:bg-zinc-700 ${
-                            selected ? "font-medium text-zinc-100" : "text-zinc-300"
-                          }`}
-                        >
-                          {opt.label}
-                        </button>
-                      );
-                    })}
+                    <ul className="flex flex-col divide-y divide-neutral-900">
+                      {SORT_OPTIONS.map((opt) => {
+                        const key = `${opt.value.sort ?? ""}:${opt.value.order ?? ""}`;
+                        const selected = key === currentSortKey;
+                        return (
+                          <li key={key}>
+                            <button
+                              type="button"
+                              role="option"
+                              aria-selected={selected}
+                              onClick={() => onSelectSort(key)}
+                              className={`flex w-full items-center justify-between px-4 py-3 text-left text-xs uppercase tracking-[0.3em] transition-colors ${
+                                selected ? "text-neutral-100" : "text-neutral-500 hover:text-neutral-200"
+                              }`}
+                            >
+                              {opt.label}
+                              {selected && <span aria-hidden className="text-[8px] text-neutral-500">ativo</span>}
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
                   </div>
                 )}
               </div>
             }
           />
+          <span className="text-[11px] uppercase tracking-[0.4em] text-neutral-600">
+            {posts.length} resultados na página atual
+          </span>
         </div>
       </div>
+
       {error ? (
-        <p className="text-red-500">{error}</p>
+        <p className="rounded border border-red-500/40 bg-red-500/5 px-4 py-3 text-sm text-red-200">{error}</p>
       ) : posts.length === 0 ? (
-        <div className="text-sm text-zinc-400 space-y-2">
-          <p>Nenhum post encontrado.</p>
-          <p>Tente ajustar a busca ou filtros.</p>
+        <div className="flex flex-col gap-1 border border-neutral-900 bg-neutral-900/40 px-6 py-8 text-sm text-neutral-400">
+          <p>Nenhum registro para os filtros informados.</p>
+          <p>Ajuste a busca ou retorne para a listagem completa.</p>
         </div>
       ) : (
-        <ul className="text-xl ml-0 flex flex-col gap-4">
+        <ul className="border border-neutral-900">
           {posts.map((post) => (
-            <li key={post.postId} className="flex flex-col mb-2 group relative">
-              <Link
-                href={`/posts/${post.postId}`}
-                className="text-xl hover:underline"
-              >
-                {post.title}
-              </Link>
-              <small className="text-zinc-400">
-                <Date dateString={post.date} /> <span aria-hidden className="mx-2">&middot;</span>
-                <span className="inline-flex items-center rounded px-2 py-1 text-sm text-zinc-500">
-                  {post.views ?? 0} views
-                </span>
-              </small>
-              {isAdmin && (
-                <button
-                  onClick={() => openDeleteModal(post.postId)}
-                  className="absolute right-0 top-0 text-red-500 hover:text-red-700 text-sm opacity-0 group-hover:opacity-100 max-sm:opacity-100 transition-opacity duration-200"
+            <li
+              key={post.postId}
+              className="grid gap-6 border-b border-neutral-900 px-6 py-6 transition-colors duration-200 hover:bg-neutral-900/40 md:grid-cols-[minmax(0,1fr)_200px] md:gap-10"
+            >
+              <div className="flex flex-col gap-4">
+                <Link
+                  href={`/posts/${post.postId}`}
+                  className="text-2xl font-semibold leading-tight tracking-tight text-neutral-50 transition-colors hover:text-neutral-100"
                 >
-                  <TrashIcon className="size-4" />
-                </button>
-              )}
+                  {post.title}
+                </Link>
+                {post.tags?.length ? (
+                  <div className="flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.35em] text-neutral-500">
+                    {post.tags.map((tag) => (
+                      <span key={tag} className="border border-neutral-800 px-2 py-1">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-col gap-3 text-xs uppercase tracking-[0.3em] text-neutral-500 md:items-end">
+                <span className="text-neutral-400">
+                  <Date dateString={post.date} />
+                </span>
+                <span className="text-neutral-500">{post.views ?? 0} leituras</span>
+                {isAdmin && (
+                  <button
+                    onClick={() => openDeleteModal(post.postId)}
+                    className="self-start border border-red-700 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.4em] text-red-400 transition-colors hover:border-red-500 hover:text-red-300 md:self-end"
+                  >
+                    remover
+                  </button>
+                )}
+              </div>
             </li>
           ))}
         </ul>
       )}
 
-      <Pagination page={page} hasNext={hasNext} pathname={pathname} searchParams={Object.fromEntries(sp.entries())} />
+      <Pagination
+        page={page}
+        hasNext={hasNext}
+        pathname={pathname}
+        searchParams={Object.fromEntries(sp.entries())}
+      />
 
       {showDeleteModal && postToDelete && isAdmin && (
-        <div className="fixed inset-0 bg-zinc-900/90 flex items-center justify-center z-50">
-          <div className="bg-white p-6 rounded-lg shadow-lg max-w-sm w-full border border-gray-200">
-            <h2 className="text-lg font-bold mb-4 text-gray-900">
-              Confirmar Exclusão
-            </h2>
-            <p className="mb-6 text-gray-700">
-              Tem certeza que deseja apagar o post "
-              <span className="font-semibold text-gray-900">
-                {posts.find((p) => p.postId === postToDelete)?.title ||
-                  "Este post"}
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-neutral-950/95 px-4">
+          <div className="w-full max-w-sm border border-neutral-800 bg-neutral-950 p-6 shadow-[0_24px_70px_rgba(0,0,0,0.65)]">
+            <h2 className="text-lg font-semibold text-neutral-100">Confirmar exclusão</h2>
+            <p className="mt-4 text-sm text-neutral-400">
+              Tem certeza que deseja apagar o post
+              <span className="ml-1 text-neutral-100">
+                {posts.find((p) => p.postId === postToDelete)?.title || "Este post"}
               </span>
-              "?
+              ?
             </p>
-            <div className="flex justify-end gap-4">
+            <div className="mt-6 flex justify-end gap-3 text-[11px] uppercase tracking-[0.4em]">
               <button
                 onClick={closeDeleteModal}
-                className="px-4 py-2 bg-gray-100 text-gray-800 rounded hover:bg-gray-200 border border-gray-300 transition-colors duration-200"
+                className="border border-neutral-700 px-3 py-2 text-neutral-400 transition-colors hover:border-neutral-500 hover:text-neutral-100"
               >
                 Cancelar
               </button>
               <button
                 onClick={() => handleDeletePost(postToDelete)}
-                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 border border-red-700 transition-colors duration-200"
+                className="border border-red-700 px-3 py-2 text-red-400 transition-colors hover:border-red-500 hover:text-red-200"
               >
                 Apagar
               </button>
@@ -248,21 +283,4 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
     </section>
   );
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -117,10 +117,20 @@ export default async function HomePage({
 
   return (
     <Layout home>
-      <Header home={true} />
-      <section className="text-xl flex flex-col gap-2 py-4 text-primary items-center">
-        <h1>Dou minhas opiniões aqui</h1>
-      </section>
+      <div className="flex flex-col gap-12">
+        <Header home={true} />
+        <section className="flex flex-col gap-5 text-sm leading-6 text-neutral-500">
+          <p>
+            Este espaço reúne posicionamentos, contrapontos e notas de leitura. Tudo segue a mesma
+            cadência: bloco direto, linguagem clara, ausência de ornamentos.
+          </p>
+          <div className="grid gap-3 text-[11px] uppercase tracking-[0.35em] text-neutral-600">
+            <span>Atualizações publicadas sem periodicidade fixa.</span>
+            <span>Contexto completo dentro de cada post, nada fragmentado.</span>
+            <span>Comentários externos não são agregados aqui.</span>
+          </div>
+        </section>
+      </div>
       <HomeClient posts={posts} isAdmin={isAdmin} page={page} hasNext={hasNext} />
     </Layout>
   );


### PR DESCRIPTION
## Summary
- rebuild the layout wrapper with a wide canvas, rigid typography, and reframed header controls
- redesign the home header, search, listing grid, pagination, and modal treatment to feel colder and more structured
- refresh global styles, typography rules, and shared widgets to match the new severe visual language

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6904534c72fc83229309ee54b2ad7b4b