### PR TITLE
Refactor comment thread rendering to use flat list

### DIFF
--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -14,6 +14,7 @@ import CommentThread from "./comments/CommentThread";
 import { CommentDraft, CommentEntity, SubmissionStatus } from "./comments/types";
 import {
   buildCommentLookup,
+  countThreadReplies,
   flattenServerComments,
   normalizeServerComment,
   sanitizeCommentHtml,
@@ -114,6 +115,10 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId, isAdmin }) =>
   }, [submissionStatus]);
 
   const commentLookup = useMemo(() => buildCommentLookup(comments), [comments]);
+  const replyCounts = useMemo(
+    () => countThreadReplies(commentLookup),
+    [commentLookup]
+  );
   const totalComments = comments.length;
 
   const commentLength = useCommentLength(
@@ -473,6 +478,11 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId, isAdmin }) =>
     [postId, removeBranch]
   );
 
+  const handleOpenThread = useCallback((_commentId: string) => {
+    // Thread visualization is handled elsewhere. This function ensures
+    // the component API remains stable when the thread viewer is introduced.
+  }, []);
+
   return (
   <section className="space-y-4" aria-label="Seção de comentários">
       <div className="mx-auto w-full">
@@ -552,8 +562,8 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId, isAdmin }) =>
 
         <div className="mt-4 space-y-4">
           <CommentThread
-            parentId={null}
             lookup={commentLookup}
+            replyCounts={replyCounts}
             onReplyRequest={handleReplyRequest}
             onReplyCancel={handleReplyCancel}
             onReplySubmit={handleReplySubmit}
@@ -565,6 +575,7 @@ const Comment: React.FC<CommentProps> = ({ postId, coAuthorUserId, isAdmin }) =>
             canDelete={canDeleteComment}
             onDelete={handleDelete}
             requiresName={!userId}
+            onOpenThread={handleOpenThread}
             coAuthorUserId={coAuthorUserId}
           />
 

--- a/components/comments/CommentItem.tsx
+++ b/components/comments/CommentItem.tsx
@@ -18,6 +18,8 @@ import {
 
 type CommentItemProps = {
   comment: CommentEntity;
+  replyCount: number;
+  onOpenThread: () => void;
   onReplyRequest: () => void;
   onReplyCancel: () => void;
   onReplySubmit: (draft: CommentDraft) => void;
@@ -29,12 +31,13 @@ type CommentItemProps = {
   canDelete: boolean;
   onDelete: () => void;
   requiresName: boolean;
-  children?: React.ReactNode;
   coAuthorUserId?: string;
 };
 
 const CommentItem: React.FC<CommentItemProps> = ({
   comment,
+  replyCount,
+  onOpenThread,
   onReplyRequest,
   onReplyCancel,
   onReplySubmit,
@@ -46,7 +49,6 @@ const CommentItem: React.FC<CommentItemProps> = ({
   canDelete,
   onDelete,
   requiresName,
-  children,
   coAuthorUserId,
 }) => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -136,6 +138,15 @@ const CommentItem: React.FC<CommentItemProps> = ({
             >
               Responder
             </button>
+            {replyCount > 0 && (
+              <button
+                type="button"
+                onClick={onOpenThread}
+                className="inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-3 py-1 text-sm font-medium text-zinc-700 transition-colors hover:border-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-zinc-700"
+              >
+                Ver thread ({replyCount})
+              </button>
+            )}
             {canDelete && (
               <>
                 <button
@@ -201,10 +212,8 @@ const CommentItem: React.FC<CommentItemProps> = ({
               errorMessage={replyError}
             />
           )}
-
-          {children && <div className="space-y-3 sm:space-y-4 border-l border-zinc-200 dark:border-zinc-700 pl-3 sm:pl-4">{children}</div>}
         </div>
-  </div>
+      </div>
     </article>
   );
 };

--- a/components/comments/CommentThread.tsx
+++ b/components/comments/CommentThread.tsx
@@ -1,4 +1,4 @@
-﻿import React from "react";
+import React from "react";
 
 import CommentItem from "./CommentItem";
 import {
@@ -9,8 +9,8 @@ import {
 } from "./types";
 
 type CommentThreadProps = {
-  parentId: string | null;
   lookup: CommentLookup;
+  replyCounts: Map<string, number>;
   onReplyRequest: (commentId: string) => void;
   onReplyCancel: (commentId: string) => void;
   onReplySubmit: (commentId: string, draft: CommentDraft) => void;
@@ -22,12 +22,13 @@ type CommentThreadProps = {
   canDelete: (comment: CommentEntity) => boolean;
   onDelete: (comment: CommentEntity) => void;
   requiresName: boolean;
+  onOpenThread: (commentId: string) => void;
   coAuthorUserId?: string;
 };
 
 const CommentThread: React.FC<CommentThreadProps> = ({
-  parentId,
   lookup,
+  replyCounts,
   onReplyRequest,
   onReplyCancel,
   onReplySubmit,
@@ -39,20 +40,23 @@ const CommentThread: React.FC<CommentThreadProps> = ({
   canDelete,
   onDelete,
   requiresName,
+  onOpenThread,
   coAuthorUserId,
 }) => {
-  const siblings = lookup.get(parentId ?? null) ?? [];
+  const topLevelComments = lookup.get(null) ?? [];
 
-  if (siblings.length === 0) {
+  if (topLevelComments.length === 0) {
     return null;
   }
 
   return (
-    <div className={parentId ? "space-y-3" : "space-y-4"}>
-      {siblings.map((comment) => (
+    <div className="space-y-4">
+      {topLevelComments.map((comment) => (
         <CommentItem
           key={comment._id}
           comment={comment}
+          replyCount={replyCounts.get(comment._id) ?? 0}
+          onOpenThread={() => onOpenThread(comment._id)}
           onReplyRequest={() => onReplyRequest(comment._id)}
           onReplyCancel={() => onReplyCancel(comment._id)}
           onReplySubmit={(draft) => onReplySubmit(comment._id, draft)}
@@ -65,28 +69,10 @@ const CommentThread: React.FC<CommentThreadProps> = ({
           onDelete={() => onDelete(comment)}
           requiresName={requiresName}
           coAuthorUserId={coAuthorUserId}
-        >
-          <CommentThread
-            parentId={comment._id}
-            lookup={lookup}
-            onReplyRequest={onReplyRequest}
-            onReplyCancel={onReplyCancel}
-            onReplySubmit={onReplySubmit}
-            onReplyDraftChange={onReplyDraftChange}
-            getReplyDraft={getReplyDraft}
-            getReplyStatus={getReplyStatus}
-            getReplyError={getReplyError}
-            isReplying={isReplying}
-            canDelete={canDelete}
-            onDelete={onDelete}
-            requiresName={requiresName}
-            coAuthorUserId={coAuthorUserId}
-          />
-        </CommentItem>
+        />
       ))}
     </div>
   );
 };
 
 export default CommentThread;
-

--- a/components/comments/utils.ts
+++ b/components/comments/utils.ts
@@ -179,3 +179,27 @@ export const extractDisplayName = (comment: CommentEntity): string => {
 
   return comment.nome || "Anonymous";
 };
+
+export const countThreadReplies = (lookup: CommentLookup): Map<string, number> => {
+  const counts = new Map<string, number>();
+
+  const visit = (comment: CommentEntity): number => {
+    const children = lookup.get(comment._id) ?? [];
+    let total = 0;
+    children.forEach((child) => {
+      total += 1 + visit(child);
+    });
+    counts.set(comment._id, total);
+    return total;
+  };
+
+  lookup.forEach((bucket) => {
+    bucket.forEach((comment) => {
+      if (!counts.has(comment._id)) {
+        visit(comment);
+      }
+    });
+  });
+
+  return counts;
+};


### PR DESCRIPTION
## Summary
- refactor the comment thread component to render only top-level comments without recursion
- add a utility to count descendant replies and surface the count through Comment and CommentItem
- update the comment item UI to expose a "Ver thread" chip and prepare for external thread viewing handlers

## Testing
- CI=1 npm run build *(fails: requires MONGODB_URI and MONGODB_DB environment variables)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f21bc0b488322b7564530c6dee38e)