### PR TITLE
Update posts header with total count

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -54,8 +54,8 @@ export default function SearchBar({ onSearch, initialQuery = "", rightSlot }: Se
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Pesquisar posts"
-          aria-label="Pesquisar posts"
+          placeholder="Pesquisar"
+          aria-label="Pesquisar"
           className="form-input-plain flex-1 min-w-0 text-sm placeholder-zinc-500 dark:placeholder-zinc-300"
         />
         {rightSlot && (

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -93,4 +93,13 @@ h1 {
   @apply sm:text-sm md:text-lg;
 }
 
+.form-input-plain:focus,
+.form-input-plain:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border-color: inherit;
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+}
+
 

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -22,6 +22,7 @@ type HomeClientProps = {
   isAdmin: boolean;
   page: number;
   hasNext: boolean;
+  total?: number;
 };
 
 const SORT_OPTIONS = [
@@ -30,13 +31,15 @@ const SORT_OPTIONS = [
   { label: "Views (menor a maior)", value: { sort: "views" as const, order: "asc" as const } },
   { label: "Views (maior a menor)", value: { sort: "views" as const, order: "desc" as const } },
 ];
-export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClientProps) {
+export default function HomeClient({ posts, isAdmin, page, hasNext, total }: HomeClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [postToDelete, setPostToDelete] = useState<string | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
   const sp = useSearchParams();
+
+  const totalCount = typeof total === "number" ? total : posts.length;
 
   const query = sp.get("query") ?? "";
   const sort = (sp.get("sort") as "date" | "views" | undefined) ?? undefined;
@@ -128,9 +131,12 @@ export default function HomeClient({ posts, isAdmin, page, hasNext }: HomeClient
 
   return (
     <section className="flex-1 gap-6">
-      <div className="flex items-center flex-wrap mb-6 gap-4">
-        <h1 className="font-bold text-2xl">Blog</h1>
-        <div className="ml-2 sm:ml-4">
+      <div className="mb-5 flex flex-col gap-3 sm:mb-6 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <h1 className="flex items-center gap-2 text-2xl font-bold">
+          Posts
+          <span>({totalCount})</span>
+        </h1>
+        <div className="w-full sm:w-auto">
           <SearchBar
             onSearch={onSearch}
             initialQuery={query}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,7 +121,7 @@ export default async function HomePage({
       <section className="text-xl flex flex-col gap-2 py-4 text-primary items-center">
         <h1>Dou minhas opiniões aqui</h1>
       </section>
-      <HomeClient posts={posts} isAdmin={isAdmin} page={page} hasNext={hasNext} />
+      <HomeClient posts={posts} isAdmin={isAdmin} page={page} hasNext={hasNext} total={total} />
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- accept an optional total count in the home client and display it in the Posts header with tighter spacing
- forward the total value from the server page data and localize the search placeholder text
- normalize the focus state on plain form inputs to remove outlines and rings

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910025863248322b753f91223fbc0fb)