### PR TITLE
Improve admin detection and resilient MongoDB client handling

### DIFF
--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -65,10 +65,14 @@ export async function resolveAdminStatus(
     return { isAdmin: false, userId: null };
   }
 
+  if (options.sessionClaims === null && !options.userId) {
+    return { isAdmin: false, userId: null };
+  }
+
   let providedSessionClaims = options.sessionClaims;
   let providedUserId = options.userId ?? null;
 
-  if (!providedSessionClaims) {
+  if (typeof providedSessionClaims === "undefined") {
     try {
       const { sessionClaims, userId } = await auth();
       providedSessionClaims = sessionClaims;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ import {
   ANALYTICS_SESSION_MAX_AGE,
   generateSessionId,
 } from "@lib/analytics/session";
+import { claimsContainAdmin } from "@lib/admin";
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -26,7 +27,7 @@ export default clerkMiddleware(async (auth, req) => {
   const authState = await auth();
   const { userId, sessionClaims, redirectToSignIn } = authState;
 
-  if (isAdminRoute(req) && sessionClaims?.metadata?.role !== "admin") {
+  if (isAdminRoute(req) && !claimsContainAdmin(sessionClaims)) {
     const url = new URL("/", req.url);
     return NextResponse.redirect(url);
   }

--- a/tests/helpers/load-module.ts
+++ b/tests/helpers/load-module.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+
+const TEMP_PREFIX = "module-mock-";
+
+type StubSources = Record<string, string>;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function writeStubModules(tempDir: string, stubs: StubSources): Promise<Map<string, string>> {
+  const entries = new Map<string, string>();
+
+  for (const [specifier, source] of Object.entries(stubs)) {
+    const fileName = `${specifier.replace(/[^a-zA-Z0-9_-]+/g, "_")}.ts`;
+    const filePath = path.join(tempDir, fileName);
+    await writeFile(filePath, source, "utf8");
+    entries.set(specifier, pathToFileURL(filePath).href);
+  }
+
+  return entries;
+}
+
+function replaceImportSpecifiers(source: string, replacements: Map<string, string>): string {
+  let transformed = source;
+  for (const [specifier, fileUrl] of replacements) {
+    const pattern = new RegExp(`from\\s+(["'])${escapeRegExp(specifier)}\\1`, "g");
+    transformed = transformed.replace(pattern, `from "${fileUrl}"`);
+  }
+  return transformed;
+}
+
+export async function loadModuleWithMocks(specifier: string, stubs: StubSources) {
+  const tempDir = await mkdtemp(path.join(tmpdir(), TEMP_PREFIX));
+  const stubEntries = await writeStubModules(tempDir, stubs);
+
+  const absolutePath = path.resolve(process.cwd(), specifier);
+  const originalSource = await readFile(absolutePath, "utf8");
+  const transformedSource = replaceImportSpecifiers(originalSource, stubEntries);
+
+  const targetPath = path.join(tempDir, "module-under-test.ts");
+  await writeFile(targetPath, transformedSource, "utf8");
+
+  const moduleUrl = pathToFileURL(targetPath).href + `?t=${Date.now()}`;
+  return import(moduleUrl);
+}

--- a/tests/middleware-admin.test.ts
+++ b/tests/middleware-admin.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { loadModuleWithMocks } from "./helpers/load-module";
+
+function createRouteMatcher(patterns: string[]) {
+  return (req: Request) => {
+    const pathname = new URL(req.url).pathname;
+    return patterns.some((pattern) => {
+      if (pattern.endsWith("(.*)")) {
+        const base = pattern.slice(0, -4);
+        return pathname.startsWith(base);
+      }
+      return pathname === pattern;
+    });
+  };
+}
+
+test("middleware allows admin role from Clerk metadata", async () => {
+  const authState = {
+    userId: "user_123",
+    sessionClaims: { publicMetadata: { role: "admin" } },
+    redirectToSignIn: () => {
+      throw new Error("redirect should not be called");
+    },
+  };
+
+  const clerkServerStub = `
+    export const clerkMiddleware = (handler) => {
+      return async (req) => handler(async () => globalThis.__TEST_AUTH_STATE, req);
+    };
+    export const createRouteMatcher = (patterns) => {
+      return (req) => {
+        const pathname = new URL(req.url).pathname;
+        return patterns.some((pattern) => {
+          if (pattern.endsWith("(.*)")) {
+            const base = pattern.slice(0, -4);
+            return pathname.startsWith(base);
+          }
+          return pathname === pattern;
+        });
+      };
+    };
+  `;
+
+  const nextServerStub = `
+    class MockCookies {
+      constructor() {
+        this.store = new Map();
+      }
+      get(name) {
+        const entry = this.store.get(name);
+        if (!entry) {
+          return undefined;
+        }
+        return { name, value: entry.value };
+      }
+      set(options) {
+        this.store.set(options.name, { value: options.value });
+      }
+    }
+
+    export class NextResponse {
+      constructor(status) {
+        this.status = status;
+        this.headers = new Headers();
+        this.cookies = new MockCookies();
+      }
+
+      static next() {
+        return new NextResponse(200);
+      }
+
+      static redirect(url) {
+        const response = new NextResponse(307);
+        response.headers.set("Location", url instanceof URL ? url.toString() : url);
+        return response;
+      }
+    }
+  `;
+
+  const analyticsStub = `
+    export const ANALYTICS_SESSION_COOKIE_NAME = "dy.sid";
+    export const ANALYTICS_SESSION_MAX_AGE = 3600;
+    export const generateSessionId = () => "session-id";
+  `;
+
+  (globalThis as typeof globalThis & { __TEST_AUTH_STATE?: typeof authState }).__TEST_AUTH_STATE = authState;
+
+  const module = await loadModuleWithMocks("src/middleware.ts", {
+    "@clerk/nextjs/server": clerkServerStub,
+    "next/server": nextServerStub,
+    "@lib/analytics/session": analyticsStub,
+  });
+
+  const middleware = module.default as (req: Request) => Promise<any>;
+
+  const request = {
+    url: "https://example.com/admin",
+    cookies: {
+      get: () => undefined,
+    },
+  } as { url: string; cookies: { get: (name: string) => undefined } };
+
+  const response = await middleware(request as unknown as Request);
+  assert.equal(response.status, 200);
+  assert.equal(response.cookies.get("dy.sid")?.value, "session-id");
+
+  delete (globalThis as typeof globalThis & { __TEST_AUTH_STATE?: typeof authState }).__TEST_AUTH_STATE;
+});

--- a/tests/mongo-client-retry.test.ts
+++ b/tests/mongo-client-retry.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { loadModuleWithMocks } from "./helpers/load-module";
+
+void test("getMongoClient retries after transient failure", async () => {
+  process.env.MONGODB_URI = "mongodb://127.0.0.1:27017/test";
+  process.env.MONGODB_DB = "blog";
+
+  const globalAny = globalThis as typeof globalThis & {
+    _mongoClientPromise?: Promise<unknown>;
+    _mongoClientPromiseLock?: Promise<void>;
+  };
+
+  delete globalAny._mongoClientPromise;
+  delete globalAny._mongoClientPromiseLock;
+
+  const fakeClient = { id: "client" };
+  let attempts = 0;
+
+  const mongoStub = `
+    export class MongoClient {
+      connect() {
+        return globalThis.__TEST_MONGO_CONNECT();
+      }
+    }
+  `;
+
+  (globalThis as typeof globalThis & { __TEST_MONGO_CONNECT?: () => Promise<unknown> }).__TEST_MONGO_CONNECT = () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return Promise.reject(new Error("temporary failure"));
+    }
+    return Promise.resolve(fakeClient);
+  };
+
+  const module = await loadModuleWithMocks("src/lib/mongo.ts", {
+    mongodb: mongoStub,
+  });
+
+  const firstPromise = module.clientPromise as Promise<unknown>;
+  firstPromise.catch(() => undefined);
+
+  const globalState = globalThis as typeof globalThis & {
+    _mongoClientPromise?: Promise<unknown>;
+    _mongoClientPromiseLock?: Promise<void>;
+  };
+
+  globalState._mongoClientPromise = firstPromise;
+
+  await assert.rejects(module.getMongoClient(), /Falha na conexão/);
+
+  const secondPromise = module.clientPromise as Promise<unknown>;
+  assert.notStrictEqual(firstPromise, secondPromise);
+
+  const client = await module.getMongoClient();
+  assert.equal(attempts, 2);
+  assert.strictEqual(client, fakeClient);
+
+  delete (globalThis as typeof globalThis & { __TEST_MONGO_CONNECT?: () => Promise<unknown> }).__TEST_MONGO_CONNECT;
+  delete globalState._mongoClientPromise;
+  delete globalState._mongoClientPromiseLock;
+});

--- a/tests/root-layout-admin.test.tsx
+++ b/tests/root-layout-admin.test.tsx
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import React, { ReactNode } from "react";
+import { test } from "node:test";
+
+import { loadModuleWithMocks } from "./helpers/load-module";
+
+const clerkServerStub = `
+  export const auth = async () => globalThis.__TEST_AUTH_STATE;
+`;
+
+const adminStub = `
+  export const resolveAdminStatus = async (...args) => globalThis.__TEST_RESOLVE_ADMIN(...args);
+`;
+
+const analyticsProviderStub = `
+  export default function AnalyticsProvider({ children, isAdmin }) {
+    globalThis.__TEST_ANALYTICS_IS_ADMIN = isAdmin;
+    return children;
+  }
+`;
+
+const clerkStub = `
+  export const ClerkProvider = ({ children }) => children;
+`;
+
+const analyticsConfigStub = `
+  export const getAnalyticsClientConfig = () => ({
+    endpoint: "/",
+    enabledEvents: [],
+    flushIntervalMs: 0,
+    maxBatchSize: 0,
+    maxQueueSize: 0,
+    readProgressSampleRate: 0,
+    readProgressMilestones: [],
+  });
+`;
+
+const analyticsComponentStub = `
+  export const Analytics = () => null;
+`;
+
+const speedInsightsStub = `
+  export const SpeedInsights = () => null;
+`;
+
+void test("RootLayout skips admin resolution for anonymous users", async () => {
+  let resolveCalls = 0;
+
+  (globalThis as typeof globalThis & {
+    __TEST_AUTH_STATE?: unknown;
+    __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
+    __TEST_ANALYTICS_IS_ADMIN?: boolean;
+  }).__TEST_AUTH_STATE = { userId: null, sessionClaims: null };
+
+  (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN = async () => {
+    resolveCalls += 1;
+    return { isAdmin: true, userId: null };
+  };
+
+  const module = await loadModuleWithMocks("src/app/layout.tsx", {
+    "@clerk/nextjs/server": clerkServerStub,
+    "@lib/admin": adminStub,
+    "@components/analytics/AnalyticsProvider": analyticsProviderStub,
+    "@clerk/nextjs": clerkStub,
+    "@lib/analytics/config": analyticsConfigStub,
+    "@vercel/analytics/react": analyticsComponentStub,
+    "@vercel/speed-insights/next": speedInsightsStub,
+  });
+
+  const RootLayout = module.default as ({ children }: { children: ReactNode }) => Promise<React.ReactNode>;
+
+  await RootLayout({ children: <div /> });
+
+  assert.equal(resolveCalls, 0);
+  assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN, false);
+
+  delete (globalThis as typeof globalThis & {
+    __TEST_AUTH_STATE?: unknown;
+    __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
+    __TEST_ANALYTICS_IS_ADMIN?: boolean;
+  }).__TEST_AUTH_STATE;
+  delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
+});
+
+void test("RootLayout forwards admin flag when user is signed in", async () => {
+  let resolveCalls = 0;
+  let receivedOptions: unknown;
+
+  (globalThis as typeof globalThis & {
+    __TEST_AUTH_STATE?: unknown;
+    __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
+    __TEST_ANALYTICS_IS_ADMIN?: boolean;
+  }).__TEST_AUTH_STATE = {
+    userId: "user_123",
+    sessionClaims: { publicMetadata: { role: "admin" } },
+  };
+
+  (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN = async (options: unknown) => {
+    resolveCalls += 1;
+    receivedOptions = options;
+    return { isAdmin: true, userId: "user_123" };
+  };
+
+  const module = await loadModuleWithMocks("src/app/layout.tsx", {
+    "@clerk/nextjs/server": clerkServerStub,
+    "@lib/admin": adminStub,
+    "@components/analytics/AnalyticsProvider": analyticsProviderStub,
+    "@clerk/nextjs": clerkStub,
+    "@lib/analytics/config": analyticsConfigStub,
+    "@vercel/analytics/react": analyticsComponentStub,
+    "@vercel/speed-insights/next": speedInsightsStub,
+  });
+
+  const RootLayout = module.default as ({ children }: { children: ReactNode }) => Promise<React.ReactNode>;
+
+  await RootLayout({ children: <div /> });
+
+  assert.equal(resolveCalls, 1);
+  assert.deepEqual(receivedOptions, {
+    sessionClaims: { publicMetadata: { role: "admin" } },
+    userId: "user_123",
+  });
+  assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN, true);
+
+  delete (globalThis as typeof globalThis & {
+    __TEST_AUTH_STATE?: unknown;
+    __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
+    __TEST_ANALYTICS_IS_ADMIN?: boolean;
+  }).__TEST_AUTH_STATE;
+  delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
+});


### PR DESCRIPTION
## Summary
- replace the middleware's direct session role comparison with the shared `claimsContainAdmin` helper so Clerk metadata roles are respected
- update the RootLayout to reuse a single Clerk auth fetch, skipping admin resolution for anonymous users while still flagging signed-in admins for analytics
- harden admin resolution and MongoDB client management by handling null session claims, recreating cached client promises with a lock, and adding focused regression tests driven by a lightweight module-mocking helper

## Testing
- `npx tsx --test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691006e520c8832297a9f8cbe42bf448)