### PR TITLE
Improve mobile layout of search and share controls

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -44,7 +44,7 @@ export default function SearchBar({ onSearch, initialQuery = "", rightSlot }: Se
 
   return (
     <form onSubmit={handleSubmit} className="relative">
-      <div className="card-surface-interactive flex items-center gap-3 px-3 py-2 w-full sm:w-auto">
+      <div className="card-surface-interactive flex items-center gap-3 px-3 py-2 w-full max-w-xs sm:max-w-sm sm:w-auto">
         <MagnifyingGlassIcon
           className="h-5 w-5 text-zinc-500 dark:text-zinc-400"
           aria-hidden="true"

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -52,10 +52,10 @@ const ShareButton: React.FC<ShareButtonProps> = ({ id }) => {
       <button
         onClick={share}
         aria-label="Compartilhar"
-        className="ml-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-cyan-600 hover:text-cyan-700 active:text-cyan-700 rounded-full border border-transparent hover:border-cyan-200/60 dark:hover:border-cyan-800/60 hover:bg-cyan-50 dark:hover:bg-cyan-950/40 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500/30"
+        className="ml-0 inline-flex shrink-0 items-center gap-1 sm:gap-2 max-sm:px-2 max-sm:py-1 sm:px-3 sm:py-1.5 text-xs sm:text-sm font-medium text-cyan-600 hover:text-cyan-700 active:text-cyan-700 rounded-md sm:rounded-full border border-transparent hover:border-cyan-200/60 dark:hover:border-cyan-800/60 hover:bg-cyan-50 dark:hover:bg-cyan-950/40 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500/30"
       >
         {/* Icon only on mobile */}
-        <ShareIcon className="h-5 w-5 block sm:hidden" aria-hidden="true" />
+        <ShareIcon className="block h-4 w-4 sm:hidden" aria-hidden="true" />
         {/* Text on sm and up */}
         <span className="hidden sm:inline">Compartilhar</span>
       </button>

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -136,7 +136,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
           Posts
           <span>({totalCount})</span>
         </h1>
-        <div className="w-full sm:w-auto">
+        <div className="w-full max-w-xs sm:w-auto sm:max-w-none">
           <SearchBar
             onSearch={onSearch}
             initialQuery={query}


### PR DESCRIPTION
## Summary
- limit the search bar width on small screens so it no longer spans edge-to-edge
- align the home search and sort controls by matching the responsive wrapper width
- tighten the share button spacing on mobile to keep the post header content on one line

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910ce51018c83229086765bfb1e91b8)