### PR TITLE
Simplify BackHome positioning

### DIFF
--- a/components/back-home.tsx
+++ b/components/back-home.tsx
@@ -1,32 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
 import { ChevronLeftIcon } from "@heroicons/react/24/outline";
 
 export function BackHome() {
-  const [left, setLeft] = useState<number | null>(null);
-  const linkRef = useRef<HTMLAnchorElement | null>(null);
-
-  useEffect(() => {
-    const computeLeft = () => {
-      const container = document.querySelector<HTMLElement>("[data-layout-container='true']");
-      if (!container) {
-        setLeft(8);
-        return;
-      }
-      const rect = container.getBoundingClientRect();
-      const width = linkRef.current?.offsetWidth ?? 40;
-      const gap = 16; // 16px fora do container
-      const next = Math.max(8, Math.floor(rect.left - gap - width));
-      setLeft(next);
-    };
-
-    computeLeft();
-    window.addEventListener("resize", computeLeft);
-    return () => window.removeEventListener("resize", computeLeft);
-  }, []);
-
   return (
     <>
       {/* Mobile: inline */}
@@ -43,18 +20,14 @@ export function BackHome() {
       </div>
 
       {/* Desktop: fixo, fora do container */}
-      <div className="hidden md:flex">
-        <Link
-          ref={linkRef}
-          href="/"
-          className="fixed top-1/2 -translate-y-1/2 z-40 flex items-center justify-center p-1.5 rounded-full text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors transition-transform duration-150 hover:scale-110"
-          style={left !== null ? { left } : undefined}
-          aria-label="Voltar para a página inicial"
-          title="Voltar para a página inicial"
-        >
-          <ChevronLeftIcon className="size-7 text-zinc-700 dark:text-zinc-300" aria-hidden="true" />
-        </Link>
-      </div>
+      <Link
+        href="/"
+        className="hidden md:flex absolute left-0 top-1/2 -translate-x-full -translate-y-1/2 -ml-4 z-40 items-center justify-center p-1.5 rounded-full text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors transition-transform duration-150 hover:scale-110"
+        aria-label="Voltar para a página inicial"
+        title="Voltar para a página inicial"
+      >
+        <ChevronLeftIcon className="size-7 text-zinc-700 dark:text-zinc-300" aria-hidden="true" />
+      </Link>
     </>
   );
 }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -17,7 +17,7 @@ export function Layout({ home = false, children }: LayoutProps) {
       <ThemeSwitcher /> {/* Botão de brilho à direita */}
       <SettingsMenu /> {/* Botão de três pontos à esquerda */}
       </div>
-      <main className={`${home ? "home" : ""} flex flex-col flex-1`}>
+      <main className={`${home ? "home" : ""} relative flex flex-col flex-1`}>
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- make the main layout container a relative positioning context
- simplify the BackHome desktop button by using CSS-only positioning and remove runtime calculations

## Testing
- npm test *(fails: Missing script "test")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910eb2ff9808322815e08c7c46fd11b)