### PR TITLE
Refine post content progress tracking and minimap

### DIFF
--- a/components/PostMinimap.tsx
+++ b/components/PostMinimap.tsx
@@ -67,12 +67,23 @@ export default function PostMinimap() {
     const updateActiveHeading = () => {
       frame = null;
 
-      const focusLine = window.scrollY + window.innerHeight * 0.4;
+      const container = document.querySelector<HTMLElement>("[data-post-content]");
+      if (!container) {
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const contentTop = containerRect.top + window.scrollY;
+      const contentBottom = containerRect.bottom + window.scrollY;
+      const focusCandidate = window.scrollY + window.innerHeight * 0.4;
+      const focusLine = Math.min(Math.max(focusCandidate, contentTop), contentBottom);
+
       let nextActiveId: string | null = headings[0]?.id ?? null;
 
       for (const heading of headings) {
-        const offsetTop = heading.element.offsetTop;
-        if (offsetTop <= focusLine) {
+        const headingRect = heading.element.getBoundingClientRect();
+        const headingTop = headingRect.top + window.scrollY;
+        if (headingTop <= focusLine) {
           nextActiveId = heading.id;
         } else {
           break;

--- a/components/useHeadingsMap.ts
+++ b/components/useHeadingsMap.ts
@@ -10,6 +10,7 @@ export type HeadingEntry = {
 type UseHeadingsMapOptions = {
   enabled?: boolean;
   dependencies?: ReadonlyArray<unknown>;
+  root?: HTMLElement | null;
 };
 
 function slugifyHeading(text: string): string {
@@ -27,6 +28,7 @@ function slugifyHeading(text: string): string {
 export function useHeadingsMap({
   enabled = true,
   dependencies = [],
+  root = null,
 }: UseHeadingsMapOptions = {}): HeadingEntry[] {
   const [headings, setHeadings] = useState<HeadingEntry[]>([]);
 
@@ -40,7 +42,13 @@ export function useHeadingsMap({
       return;
     }
 
-    const nodes = Array.from(document.querySelectorAll("h4"));
+    const rootNode = root ?? document.querySelector<HTMLElement>("[data-post-content]");
+    if (!rootNode) {
+      setHeadings([]);
+      return;
+    }
+
+    const nodes = Array.from(rootNode.querySelectorAll("h4"));
     const slugCounts = new Map<string, number>();
 
     const nextHeadings = nodes.map((node) => {
@@ -63,8 +71,14 @@ export function useHeadingsMap({
       } satisfies HeadingEntry;
     });
 
+    nextHeadings.forEach((heading) => {
+      if (!heading.element.id) {
+        heading.element.id = heading.id;
+      }
+    });
+
     setHeadings(nextHeadings);
-  }, [enabled, ...dependencies]);
+  }, [enabled, root, ...dependencies]);
 
   return headings;
 }


### PR DESCRIPTION
## Summary
- add a stable post content container ref for progress tracking and minimap consumers
- clamp scroll progress updates to the article bounds and update CSS variables accordingly
- limit minimap headings queries and focus logic to the post content container only

## Testing
- npm run build *(fails: requires MONGODB_URI and MONGODB_DB)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691300c591748322a7d848259ab74765)