### PR TITLE
Add subtitle support across posts and admin tools

### DIFF
--- a/components/PostHeader.tsx
+++ b/components/PostHeader.tsx
@@ -6,11 +6,12 @@ import Image from "next/image";
 type PostHeaderProps = {
   cape?: string; // Link opcional para a imagem principal (capa)
   title: string; // Título do post
+  subtitle?: string; // Subtítulo opcional
   friendImage?: string; // Link opcional para a foto do amigo
   coAuthorImageUrl?: string | null;
 };
 
-export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostHeaderProps) {
+export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUrl }: PostHeaderProps) {
   const secondaryImage = coAuthorImageUrl || friendImage || undefined;
 
   return (
@@ -55,6 +56,9 @@ export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostH
                 )}
               </div>
               <h1 className="text-xl text-white">{title}</h1>
+              {subtitle ? (
+                <p className="text-sm text-zinc-200 drop-shadow">{subtitle}</p>
+              ) : null}
             </div>
           </div>
         </div>
@@ -85,6 +89,7 @@ export function PostHeader({ cape, title, friendImage, coAuthorImageUrl }: PostH
             )}
           </div>
           <h1 className=" ">{title}</h1>
+          {subtitle ? <p className="text-sm text-zinc-300 text-center">{subtitle}</p> : null}
         </div>
       )}
     </div>

--- a/components/PostReference.tsx
+++ b/components/PostReference.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 type PostReferenceMetadata = {
   postId: string;
   title: string;
+  subtitle: string | null;
   date: string;
   thumbnailUrl: string | null;
 };
@@ -108,6 +109,8 @@ export default function PostReference({ slug }: PostReferenceProps) {
     return title.slice(0, limit - 1) + "…";
   }, [state]);
 
+  const subtitle = state.status === "loaded" ? state.data.subtitle ?? null : null;
+
   const commonProps = {
     "data-role": "post-reference",
     "data-slug": slug,
@@ -148,6 +151,11 @@ export default function PostReference({ slug }: PostReferenceProps) {
           <span className="font-medium" title={data.title}>
             {truncatedTitle}
           </span>
+          {subtitle ? (
+            <span className="text-xs text-zinc-300" title={subtitle}>
+              {subtitle}
+            </span>
+          ) : null}
           {formattedDate ? (
             <time dateTime={data.date} className="text-xs text-zinc-400">
               {formattedDate}

--- a/src/app/admin/api/editor/route.ts
+++ b/src/app/admin/api/editor/route.ts
@@ -14,6 +14,7 @@ export async function POST(req: Request) {
   try {
     const formData = await req.formData();
     const title = formData.get("title");
+    const subtitle = formData.get("subtitle");
     const postId = formData.get("postId");
     const content = formData.get("content");
     const tags = formData.get("tags");
@@ -42,6 +43,13 @@ export async function POST(req: Request) {
         { status: 400 }
       );
     }
+    if (subtitle && typeof subtitle !== "string") {
+      return NextResponse.json(
+        { error: "Subtitle must be a string" },
+        { status: 400 }
+      );
+    }
+
     if (!content || typeof content !== "string") {
       return NextResponse.json(
         { error: "Content is required and must be a string" },
@@ -67,6 +75,10 @@ export async function POST(req: Request) {
       );
     }
 
+    const normalizedSubtitle =
+      subtitle && typeof subtitle === "string" && subtitle.trim() !== ""
+        ? subtitle.trim()
+        : null;
     const normalizedAudioUrl = audioUrl && typeof audioUrl === "string" ? audioUrl : null;
     const normalizedCape = cape && typeof cape === "string" ? cape : null;
     const normalizedFriendImage =
@@ -93,6 +105,7 @@ export async function POST(req: Request) {
     const newPost = {
       postId,
       title,
+      subtitle: normalizedSubtitle,
       htmlContent: content, // Armazena o conteúdo como Markdown (htmlContent para consistência com o projeto)
       date: new Date().toISOString().split("T")[0], // Formato "YYYY-MM-DD"
       views: 0, // Inicializa as views como 0

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 export default function Editor() {
   const [title, setTitle] = useState("");
+  const [subtitle, setSubtitle] = useState("");
   const [postId, setPostId] = useState("");
   const [cape, setCape] = useState("");
   const [friendImage, setFriendImage] = useState("");
@@ -29,6 +30,7 @@ export default function Editor() {
 
       const formData = new FormData();
       formData.append("title", title);
+      formData.append("subtitle", subtitle);
       formData.append("postId", postId);
       formData.append("content", content);
       formData.append("tags", tags);
@@ -57,6 +59,7 @@ export default function Editor() {
       await response.json();
       setSuccess("Post criado com sucesso!");
       setTitle("");
+      setSubtitle("");
       setPostId("");
       setCape("");
       setFriendImage("");
@@ -98,6 +101,17 @@ export default function Editor() {
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 required
+              />
+            </label>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-zinc-300">Subtítulo</span>
+              <input
+                name="subtitle"
+                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
+                type="text"
+                placeholder="Resumo curto do post"
+                value={subtitle}
+                onChange={(e) => setSubtitle(e.target.value)}
               />
             </label>
             <label className="flex flex-col gap-2">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ type PostRow = {
   _id?: string;
   postId: string;
   title: string;
+  subtitle?: string | null;
   date?: string;
   views?: number;
   hidden?: boolean;
@@ -43,6 +44,7 @@ export default async function AdminDashboard() {
             _id: 0,
             postId: 1,
             title: 1,
+            subtitle: 1,
             date: 1,
             views: 1,
             coAuthorUserId: 1,

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -22,6 +22,7 @@ type PostDocument = {
   postId: string;
   date: string | Date;
   title: string;
+  subtitle?: string | null;
   htmlContent?: string;
   content?: string;
   views?: number;
@@ -51,6 +52,7 @@ async function fetchPostById(id: string) {
           postId: 1,
           date: 1,
           title: 1,
+          subtitle: 1,
           htmlContent: 1,
           content: 1,
           views: 1,
@@ -169,6 +171,10 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
   }
 
   const title = post.title ?? "";
+  const subtitle =
+    typeof post.subtitle === "string" && post.subtitle.trim() !== ""
+      ? post.subtitle.trim()
+      : null;
   const date = normalizeDate(post.date);
   const BASE_URL = "https://domenyk.com";
   const FALLBACK_IMAGE_PATH = "/images/profile.jpg";
@@ -179,7 +185,11 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
   const updatedAt = normalizeDate(post.updatedAt);
   const publishedTime = date || undefined;
   const modifiedTime = updatedAt || undefined;
-  const description = extractDescription(post);
+  const descriptionCandidate = subtitle ?? extractDescription(post);
+  const description =
+    descriptionCandidate && descriptionCandidate.trim() !== ""
+      ? descriptionCandidate.trim()
+      : title;
 
   const openGraph: Metadata["openGraph"] = {
     title,
@@ -277,6 +287,10 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   const title = post.title ?? "";
+  const subtitle =
+    typeof post.subtitle === "string" && post.subtitle.trim() !== ""
+      ? post.subtitle.trim()
+      : null;
   const markdownSource = post.htmlContent ?? post.content ?? "";
   const shouldUseMdxRenderer = process.env.FEATURE_MDX_RENDERER === "true";
 
@@ -305,6 +319,12 @@ export default async function PostPage({ params }: PostPageProps) {
   const path = `/posts/${post.postId}`;
   const paragraphCommentsEnabled = post.paragraphCommentsEnabled !== false;
 
+  const descriptionCandidate = subtitle ?? extractDescription(post);
+  const description =
+    descriptionCandidate && descriptionCandidate.trim() !== ""
+      ? descriptionCandidate.trim()
+      : title;
+
   let coAuthorImageUrl: string | null = null;
   if (!isStaticGenerationEnvironment()) {
     try {
@@ -323,6 +343,7 @@ export default async function PostPage({ params }: PostPageProps) {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: title,
+    description: description,
     datePublished: dateString,
     dateModified: dateString,
     author: {
@@ -336,7 +357,7 @@ export default async function PostPage({ params }: PostPageProps) {
   };
 
   return (
-    <Layout title={title} description={title} url={path}>
+    <Layout title={title} description={description} url={path}>
       <script
         type="application/ld+json"
         suppressHydrationWarning
@@ -345,6 +366,7 @@ export default async function PostPage({ params }: PostPageProps) {
       <PostHeader
         cape={post.cape}
         title={title}
+        subtitle={subtitle ?? undefined}
         friendImage={post.friendImage}
         coAuthorImageUrl={coAuthorImageUrl}
       />

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -4,6 +4,7 @@ import { getMongoDb } from "../lib/mongo";
 export type PostRecord = {
   postId: string;
   title: string;
+  subtitle: string | null;
   date: string; // ISO string
   views: number;
   tags: string[];
@@ -29,6 +30,7 @@ export type FetchPostsResult = {
 export type PostReferenceMetadata = {
   postId: string;
   title: string;
+  subtitle: string | null;
   date: string;
   thumbnailUrl: string | null;
 };
@@ -90,6 +92,7 @@ export async function getPosts({
     _id: 0,
     postId: 1,
     title: 1,
+    subtitle: 1,
     date: 1,
     views: 1,
     tags: 1,
@@ -108,6 +111,10 @@ export async function getPosts({
   const posts: PostRecord[] = items.map((post: any) => ({
     postId: String(post.postId),
     title: String(post.title ?? ""),
+    subtitle:
+      typeof post.subtitle === "string" && post.subtitle.trim() !== ""
+        ? post.subtitle.trim()
+        : null,
     date: normalizeDate(post.date),
     views: typeof post.views === "number" ? post.views : 0,
     tags: Array.isArray(post.tags)
@@ -160,6 +167,7 @@ export async function getPostReferenceMetadata(
         _id: 0,
         postId: 1,
         title: 1,
+        subtitle: 1,
         date: 1,
         cape: 1,
         friendImage: 1,
@@ -173,6 +181,10 @@ export async function getPostReferenceMetadata(
 
   const title = record.title ? String(record.title) : "";
   const postId = record.postId ? String(record.postId) : slug;
+  const subtitle =
+    typeof (record as any).subtitle === "string" && (record as any).subtitle.trim() !== ""
+      ? String((record as any).subtitle).trim()
+      : null;
   const date = normalizeDate(record.date);
 
   let thumbnailUrl: string | null = null;
@@ -189,6 +201,7 @@ export async function getPostReferenceMetadata(
   return {
     postId,
     title,
+    subtitle,
     date,
     thumbnailUrl,
   };

--- a/tests/get-posts-hidden.test.ts
+++ b/tests/get-posts-hidden.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 type RawPost = {
   postId: string;
   title: string;
+  subtitle?: string | null;
   date: string;
   views: number;
   tags: string[];
@@ -23,6 +24,7 @@ test("admins can fetch hidden posts while non-admins cannot", async () => {
     {
       postId: "public-post",
       title: "Public",
+      subtitle: "Publicado para todos",
       date: "2024-01-01T00:00:00.000Z",
       views: 100,
       tags: ["general"],
@@ -120,6 +122,9 @@ test("admins can fetch hidden posts while non-admins cannot", async () => {
 
   const visitorSlugs = visitorResult.posts.map((post) => post.postId);
   const adminSlugs = adminResult.posts.map((post) => post.postId);
+  const adminPublicPost = adminResult.posts.find((post) => post.postId === "public-post");
+
+  assert.equal(adminPublicPost?.subtitle, "Publicado para todos");
 
   assert.ok(!visitorSlugs.includes("hidden-post"));
   assert.ok(adminSlugs.includes("hidden-post"));

--- a/tests/post-reference.test.tsx
+++ b/tests/post-reference.test.tsx
@@ -29,6 +29,7 @@ test("renders metadata when lookup succeeds", async () => {
   const metadata = {
     postId: "meu-post",
     title: "Meu Post",
+    subtitle: "Resumo do post",
     date: "2024-01-01T00:00:00.000Z",
     thumbnailUrl: "https://example.com/thumb.jpg",
   };
@@ -57,6 +58,11 @@ test("renders metadata when lookup succeeds", async () => {
     (node) => node.type === "span" && node.props.className?.includes("font-medium")
   );
   assert.equal(titleNode.props.children, metadata.title);
+
+  const subtitleNode = root.find(
+    (node) => node.type === "span" && node.props.title === metadata.subtitle
+  );
+  assert.equal(subtitleNode.props.children, metadata.subtitle);
 
   const timeNode = root.findByType("time");
   assert.equal(timeNode.props.dateTime, metadata.date);


### PR DESCRIPTION
## Summary
- add subtitle storage to post queries and reference metadata so front-end consumers receive the field
- prioritise subtitles in post metadata/layout rendering and surface them within post headers
- extend admin editor, dashboard APIs, and UI to capture and edit subtitles, with updated tests covering the new field

## Testing
- npx tsx --test tests/get-posts-hidden.test.ts
- npx tsx --test tests/post-reference.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913da6cb2a08322b861544f49376783)