### PR TITLE
Improve sitemap fallback and enrich post metadata

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -218,6 +218,9 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
   return {
     title: `${title} - Blog`,
     description,
+    alternates: {
+      canonical: url,
+    },
     openGraph,
     twitter: {
       site: "@l31t1",
@@ -279,6 +282,7 @@ export default async function PostPage({ params }: PostPageProps) {
   const title = post.title ?? "";
   const markdownSource = post.htmlContent ?? post.content ?? "";
   const shouldUseMdxRenderer = process.env.FEATURE_MDX_RENDERER === "true";
+  const description = extractDescription(post);
 
   let htmlContent: string;
 
@@ -304,6 +308,15 @@ export default async function PostPage({ params }: PostPageProps) {
   const views = typeof post.views === "number" ? post.views : 0;
   const path = `/posts/${post.postId}`;
   const paragraphCommentsEnabled = post.paragraphCommentsEnabled !== false;
+  const BASE_URL = "https://domenyk.com";
+  const FALLBACK_IMAGE_PATH = "/images/profile.jpg";
+  const cape = typeof post.cape === "string" ? post.cape.trim() : "";
+  const imageSource = cape || FALLBACK_IMAGE_PATH;
+  const imageUrl = new URL(imageSource, BASE_URL).toString();
+  const updatedAt = normalizeDate(post.updatedAt);
+  const modifiedTime = updatedAt || "";
+  const canonicalUrl = `${BASE_URL}${path}`;
+  const dateModified = modifiedTime || dateString || undefined;
 
   let coAuthorImageUrl: string | null = null;
   if (!isStaticGenerationEnvironment()) {
@@ -323,16 +336,18 @@ export default async function PostPage({ params }: PostPageProps) {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: title,
-    datePublished: dateString,
-    dateModified: dateString,
+    ...(dateString ? { datePublished: dateString } : {}),
+    ...(dateModified ? { dateModified } : {}),
     author: {
       '@type': 'Person',
       name: 'Domenyk',
     },
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': `https://domenyk.com${path}`,
+      '@id': canonicalUrl,
     },
+    image: imageUrl,
+    description,
   };
 
   return (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,5 @@
+import { promises as fs } from "fs";
+import path from "path";
 import type { MetadataRoute } from "next";
 
 import { BASE_URL } from "../lib/base-url";
@@ -6,29 +8,7 @@ import { getMongoDb } from "../lib/mongo";
 export const revalidate = 60;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const db = await getMongoDb();
-  const postsCollection = db.collection<{ postId: string; date?: Date | string }>("posts");
-
-  const posts = await postsCollection
-    .find({ hidden: { $ne: true } }, { projection: { _id: 0, postId: 1, date: 1 } })
-    .sort({ date: -1 })
-    .toArray();
-
   const fallbackDate = new Date();
-
-  const postEntries = posts
-    .filter((post) => Boolean(post.postId))
-    .map((post) => {
-      const { postId, date } = post;
-      const lastModifiedValue = date ? new Date(date) : fallbackDate;
-
-      return {
-        url: `${BASE_URL}/posts/${postId}`,
-        lastModified: Number.isNaN(lastModifiedValue.getTime()) ? fallbackDate : lastModifiedValue,
-        priority: 0.8,
-      } satisfies MetadataRoute.Sitemap[number];
-    });
-
   const staticEntries: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
@@ -37,5 +17,100 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  return [...staticEntries, ...postEntries];
+  const cachePath = path.join(process.cwd(), ".cache", "sitemap.json");
+
+  try {
+    const db = await getMongoDb();
+    const postsCollection = db.collection<{ postId: string; date?: Date | string }>("posts");
+
+    const posts = await postsCollection
+      .find({ hidden: { $ne: true } }, { projection: { _id: 0, postId: 1, date: 1 } })
+      .sort({ date: -1 })
+      .toArray();
+
+    const postEntries = posts
+      .filter((post) => Boolean(post.postId))
+      .map((post) => {
+        const { postId, date } = post;
+        const lastModifiedValue = date ? new Date(date) : fallbackDate;
+
+        return {
+          url: `${BASE_URL}/posts/${postId}`,
+          lastModified: Number.isNaN(lastModifiedValue.getTime()) ? fallbackDate : lastModifiedValue,
+          priority: 0.8,
+        } satisfies MetadataRoute.Sitemap[number];
+      });
+
+    const sitemapEntries: MetadataRoute.Sitemap = [...staticEntries, ...postEntries];
+
+    await persistCache(cachePath, sitemapEntries);
+
+    return sitemapEntries;
+  } catch (error) {
+    console.error("Failed to generate sitemap from MongoDB:", error);
+
+    const cached = await readCache(cachePath);
+    if (cached.length > 0) {
+      return cached;
+    }
+
+    return staticEntries;
+  }
+}
+
+async function persistCache(cachePath: string, sitemapEntries: MetadataRoute.Sitemap) {
+  try {
+    const cacheDirectory = path.dirname(cachePath);
+    await fs.mkdir(cacheDirectory, { recursive: true });
+    const serializableEntries = sitemapEntries.map((entry) => ({
+      ...entry,
+      lastModified:
+        entry.lastModified instanceof Date ? entry.lastModified.toISOString() : entry.lastModified,
+    }));
+
+    await fs.writeFile(cachePath, JSON.stringify(serializableEntries), "utf-8");
+  } catch (error) {
+    console.error("Failed to persist sitemap cache:", error);
+  }
+}
+
+async function readCache(cachePath: string): Promise<MetadataRoute.Sitemap> {
+  try {
+    const cached = await fs.readFile(cachePath, "utf-8");
+    const parsed = JSON.parse(cached);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+
+        const lastModifiedValue =
+          "lastModified" in entry && typeof entry.lastModified === "string"
+            ? new Date(entry.lastModified)
+            : undefined;
+
+        const normalizedLastModified =
+          lastModifiedValue && !Number.isNaN(lastModifiedValue.getTime())
+            ? lastModifiedValue
+            : undefined;
+
+        return {
+          url: entry.url,
+          lastModified: normalizedLastModified,
+          changeFrequency: entry.changeFrequency,
+          priority: entry.priority,
+        } satisfies MetadataRoute.Sitemap[number];
+      })
+      .filter((entry): entry is MetadataRoute.Sitemap[number] => Boolean(entry?.url));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error("Failed to read sitemap cache:", error);
+    }
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- wrap the sitemap's MongoDB access in error handling and persist the last successful result for resilience
- add a canonical URL to the post metadata so alternates stay aligned with existing Open Graph and Twitter data
- extend the post JSON-LD with description, image, and modified date handling that prefers the updated timestamp

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913dd3cf19883228175ae8b56892605)