### PR TITLE
Fix metadata description fallback and sitemap cache handling

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,34 +1,13 @@
+import { promises as fs } from "fs";
+import path from "path";
 import type { MetadataRoute } from "next";
 
 import { BASE_URL } from "../lib/base-url";
-import { getMongoDb } from "../lib/mongo";
 
 export const revalidate = 60;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const db = await getMongoDb();
-  const postsCollection = db.collection<{ postId: string; date?: Date | string }>("posts");
-
-  const posts = await postsCollection
-    .find({ hidden: { $ne: true } }, { projection: { _id: 0, postId: 1, date: 1 } })
-    .sort({ date: -1 })
-    .toArray();
-
   const fallbackDate = new Date();
-
-  const postEntries = posts
-    .filter((post) => Boolean(post.postId))
-    .map((post) => {
-      const { postId, date } = post;
-      const lastModifiedValue = date ? new Date(date) : fallbackDate;
-
-      return {
-        url: `${BASE_URL}/posts/${postId}`,
-        lastModified: Number.isNaN(lastModifiedValue.getTime()) ? fallbackDate : lastModifiedValue,
-        priority: 0.8,
-      } satisfies MetadataRoute.Sitemap[number];
-    });
-
   const staticEntries: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
@@ -37,5 +16,111 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  return [...staticEntries, ...postEntries];
+  const cachePath = path.join(process.cwd(), ".cache", "sitemap.json");
+
+  try {
+    const { getMongoDb } = await import("../lib/mongo");
+    const db = await getMongoDb();
+    const postsCollection = db.collection<{ postId: string; date?: Date | string }>("posts");
+
+    const posts = await postsCollection
+      .find({ hidden: { $ne: true } }, { projection: { _id: 0, postId: 1, date: 1 } })
+      .sort({ date: -1 })
+      .toArray();
+
+    const postEntries = posts
+      .filter((post) => Boolean(post.postId))
+      .map((post) => {
+        const { postId, date } = post;
+        const lastModifiedValue = date ? new Date(date) : fallbackDate;
+
+        return {
+          url: `${BASE_URL}/posts/${postId}`,
+          lastModified: Number.isNaN(lastModifiedValue.getTime()) ? fallbackDate : lastModifiedValue,
+          priority: 0.8,
+        } satisfies MetadataRoute.Sitemap[number];
+      });
+
+    const sitemapEntries: MetadataRoute.Sitemap = [...staticEntries, ...postEntries];
+
+    await persistCache(cachePath, sitemapEntries);
+
+    return sitemapEntries;
+  } catch (error) {
+    console.error("Failed to generate sitemap from MongoDB:", error);
+
+    const cached = await readCache(cachePath);
+    if (cached.length > 0) {
+      return cached;
+    }
+
+    return staticEntries;
+  }
+}
+
+async function persistCache(cachePath: string, sitemapEntries: MetadataRoute.Sitemap) {
+  try {
+    const cacheDirectory = path.dirname(cachePath);
+    await fs.mkdir(cacheDirectory, { recursive: true });
+    const serializableEntries = sitemapEntries.map((entry) => ({
+      ...entry,
+      lastModified:
+        entry.lastModified instanceof Date ? entry.lastModified.toISOString() : entry.lastModified,
+    }));
+
+    await fs.writeFile(cachePath, JSON.stringify(serializableEntries), "utf-8");
+  } catch (error) {
+    console.error("Failed to persist sitemap cache:", error);
+  }
+}
+
+async function readCache(cachePath: string): Promise<MetadataRoute.Sitemap> {
+  try {
+    const cached = await fs.readFile(cachePath, "utf-8");
+    const parsed = JSON.parse(cached);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const normalizedEntries: MetadataRoute.Sitemap = [];
+
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+
+      const url = typeof entry.url === "string" ? entry.url : undefined;
+      if (!url) {
+        continue;
+      }
+
+      const lastModifiedValue =
+        "lastModified" in entry && typeof entry.lastModified === "string"
+          ? new Date(entry.lastModified)
+          : undefined;
+
+      const normalizedLastModified =
+        lastModifiedValue && !Number.isNaN(lastModifiedValue.getTime())
+          ? lastModifiedValue
+          : undefined;
+
+      normalizedEntries.push({
+        url,
+        lastModified: normalizedLastModified,
+        changeFrequency:
+          typeof entry.changeFrequency === "string"
+            ? entry.changeFrequency
+            : undefined,
+        priority: typeof entry.priority === "number" ? entry.priority : undefined,
+      });
+    }
+
+    return normalizedEntries;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error("Failed to read sitemap cache:", error);
+    }
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary
- wrap the sitemap's MongoDB access in error handling, persist the last successful result, and lazily import the client so builds handle missing env gracefully
- add a canonical URL to the post metadata so alternates stay aligned with existing Open Graph and Twitter data while ensuring the description falls back to the subtitle or title
- extend the post JSON-LD with description, image, and modified date handling that prefers the updated timestamp and keeps fields consistent with metadata

## Testing
- npm run build *(fails: Defina MONGODB_URI e MONGODB_DB no ambiente (.env))*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913dd3cf19883228175ae8b56892605)