### PR TITLE
Refine analytics tracking to drop read progress and segment views

### DIFF
--- a/src/app/api/analytics/collect/route.ts
+++ b/src/app/api/analytics/collect/route.ts
@@ -61,6 +61,7 @@ type NormalizedEvent = {
   };
   flags?: {
     isSampled?: boolean;
+    isAuthenticated?: boolean;
   };
   userAgent?: string;
   origin?: string;
@@ -130,9 +131,12 @@ function sanitizeFlags(value: unknown) {
     return undefined;
   }
   const flags = value as Record<string, unknown>;
-  const result: { isSampled?: boolean } = {};
+  const result: { isSampled?: boolean; isAuthenticated?: boolean } = {};
   if (typeof flags.isSampled === "boolean") {
     result.isSampled = flags.isSampled;
+  }
+  if (typeof flags.isAuthenticated === "boolean") {
+    result.isAuthenticated = flags.isAuthenticated;
   }
   return Object.keys(result).length > 0 ? result : undefined;
 }
@@ -281,15 +285,6 @@ async function parseEvents(
     const event = eventInput as IncomingEvent;
     const name = typeof event.name === "string" ? event.name.trim() : "";
     if (!isKnownEvent(name) || !serverConfig.enabledEvents.has(name)) {
-      continue;
-    }
-
-    if (
-      name === "read_progress" &&
-      serverConfig.readProgressSampleRate >= 0 &&
-      serverConfig.readProgressSampleRate < 1 &&
-      Math.random() > serverConfig.readProgressSampleRate
-    ) {
       continue;
     }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,12 +38,18 @@ export default async function RootLayout({ children }: RootLayoutProps) {
     }
   }
 
+  const isAuthenticated = Boolean(authState?.userId);
+
   return (
     <ClerkProvider>
       <html lang="pt-BR">
         <body className="min-h-screen bg-zinc-900 text-white">
           <Suspense fallback={null}>
-            <AnalyticsProvider isAdmin={isAdmin} config={analyticsConfig}>
+            <AnalyticsProvider
+              isAdmin={isAdmin}
+              config={analyticsConfig}
+              isAuthenticated={isAuthenticated}
+            >
               {children}
             </AnalyticsProvider>
           </Suspense>

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -6,7 +6,6 @@ const DEFAULT_MAX_BATCH_SIZE = 10;
 const DEFAULT_MAX_QUEUE_SIZE = 40;
 const DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 60;
 const DEFAULT_RATE_LIMIT_MAX_EVENTS = 120;
-const DEFAULT_PROGRESS_SAMPLE_RATE = 1;
 const DEFAULT_MAX_EVENTS_PER_REQUEST = 25;
 const DEFAULT_MAX_EVENT_BYTES = 4096;
 
@@ -52,8 +51,6 @@ export type AnalyticsClientConfig = {
   flushIntervalMs: number;
   maxBatchSize: number;
   maxQueueSize: number;
-  readProgressSampleRate: number;
-  readProgressMilestones: number[];
 };
 
 export type AnalyticsServerConfig = {
@@ -66,7 +63,6 @@ export type AnalyticsServerConfig = {
   };
   maxEventsPerRequest: number;
   maxEventBytes: number;
-  readProgressSampleRate: number;
 };
 
 export function getAnalyticsClientConfig(): AnalyticsClientConfig {
@@ -83,27 +79,12 @@ export function getAnalyticsClientConfig(): AnalyticsClientConfig {
     min: 1,
     max: 200,
   });
-  const readProgressSampleRate = toNumber(
-    process.env.ANALYTICS_PROGRESS_SAMPLE_RATE,
-    DEFAULT_PROGRESS_SAMPLE_RATE,
-    { min: 0, max: 1 }
-  );
-
-  const readProgressMilestones = process.env.ANALYTICS_PROGRESS_MILESTONES
-    ? process.env.ANALYTICS_PROGRESS_MILESTONES
-        .split(",")
-        .map((item) => Number(item.trim()))
-        .filter((milestone) => Number.isFinite(milestone) && milestone > 0 && milestone <= 1)
-    : [0.25, 0.5, 0.75, 1.0];
-
   return {
     endpoint: DEFAULT_ENDPOINT,
     enabledEvents,
     flushIntervalMs,
     maxBatchSize,
     maxQueueSize,
-    readProgressSampleRate,
-    readProgressMilestones,
   };
 }
 
@@ -131,12 +112,6 @@ export function getAnalyticsServerConfig(): AnalyticsServerConfig {
     DEFAULT_MAX_EVENT_BYTES,
     { min: 512, max: 16_384 }
   );
-  const readProgressSampleRate = toNumber(
-    process.env.ANALYTICS_PROGRESS_SAMPLE_RATE,
-    DEFAULT_PROGRESS_SAMPLE_RATE,
-    { min: 0, max: 1 }
-  );
-
   return {
     endpoint: DEFAULT_ENDPOINT,
     enabledEvents,
@@ -147,6 +122,5 @@ export function getAnalyticsServerConfig(): AnalyticsServerConfig {
     },
     maxEventsPerRequest,
     maxEventBytes,
-    readProgressSampleRate,
   };
 }

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,7 +1,5 @@
 export const ANALYTICS_EVENT_NAMES = [
   "page_view",
-  "read_progress",
-  "read_complete",
   "para_open",
   "comment_submit",
   "search_query",
@@ -12,8 +10,6 @@ export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number];
 
 const DEFAULT_EVENTS: AnalyticsEventName[] = [
   "page_view",
-  "read_progress",
-  "read_complete",
   "comment_submit",
 ];
 

--- a/tests/root-layout-admin.test.tsx
+++ b/tests/root-layout-admin.test.tsx
@@ -13,8 +13,9 @@ const adminStub = `
 `;
 
 const analyticsProviderStub = `
-  export default function AnalyticsProvider({ children, isAdmin }) {
+  export default function AnalyticsProvider({ children, isAdmin, isAuthenticated }) {
     globalThis.__TEST_ANALYTICS_IS_ADMIN = isAdmin;
+    globalThis.__TEST_ANALYTICS_IS_AUTHENTICATED = isAuthenticated;
     return children;
   }
 `;
@@ -30,8 +31,6 @@ const analyticsConfigStub = `
     flushIntervalMs: 0,
     maxBatchSize: 0,
     maxQueueSize: 0,
-    readProgressSampleRate: 0,
-    readProgressMilestones: [],
   });
 `;
 
@@ -50,6 +49,7 @@ void test("RootLayout skips admin resolution for anonymous users", async () => {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
+    __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
   }).__TEST_AUTH_STATE = { userId: null, sessionClaims: null };
 
   (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN = async () => {
@@ -73,14 +73,20 @@ void test("RootLayout skips admin resolution for anonymous users", async () => {
 
   assert.equal(resolveCalls, 0);
   assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN, false);
+  assert.equal(
+    (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED,
+    false,
+  );
 
   delete (globalThis as typeof globalThis & {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
+    __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
   }).__TEST_AUTH_STATE;
   delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED;
 });
 
 void test("RootLayout forwards admin flag when user is signed in", async () => {
@@ -91,6 +97,7 @@ void test("RootLayout forwards admin flag when user is signed in", async () => {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
+    __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
   }).__TEST_AUTH_STATE = {
     userId: "user_123",
     sessionClaims: { publicMetadata: { role: "admin" } },
@@ -122,12 +129,18 @@ void test("RootLayout forwards admin flag when user is signed in", async () => {
     userId: "user_123",
   });
   assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN, true);
+  assert.equal(
+    (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED,
+    true,
+  );
 
   delete (globalThis as typeof globalThis & {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
+    __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
   }).__TEST_AUTH_STATE;
   delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED;
 });


### PR DESCRIPTION
## Summary
- remove read progress/read complete events from the analytics client and backend collection flow
- derive the current authentication state for analytics, persist it via flags, and surface segmented page view metrics in the admin dashboard
- simplify the admin analytics UI by removing read progress funnels, adding referrer domains, and showing authenticated vs anonymous view counts

## Testing
- node --test "tests/**/*.test.*" *(fails: module resolution errors loading test helpers)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ec1cdb588322a6296ce5366a31e5)