### PR TITLE
Limit post metadata descriptions to subtitles

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -184,15 +184,11 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
   const updatedAt = normalizeDate(post.updatedAt);
   const publishedTime = date || undefined;
   const modifiedTime = updatedAt || undefined;
-  const descriptionCandidate = subtitle ?? extractDescription(post);
-  const description =
-    descriptionCandidate && descriptionCandidate.trim() !== ""
-      ? descriptionCandidate.trim()
-      : title;
+  const description = subtitle;
 
   const openGraph: Metadata["openGraph"] = {
     title,
-    description,
+    ...(description ? { description } : {}),
     url,
     type: "article",
     images: [
@@ -226,7 +222,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
 
   return {
     title: `${title} - Blog`,
-    description,
+    ...(description ? { description } : {}),
     alternates: {
       canonical: url,
     },
@@ -235,7 +231,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
       site: "@l31t1",
       card: "summary_large_image",
       title,
-      description,
+      ...(description ? { description } : {}),
       images: [imageUrl],
     },
     ...(Object.keys(other).length ? { other } : {}),

--- a/tests/post-metadata.test.ts
+++ b/tests/post-metadata.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+import { afterEach, test } from "node:test";
+
+const TEMP_PREFIX = "post-metadata-module-";
+
+type StubSources = Record<string, string>;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __mockPost: unknown;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function writeStubModules(tempDir: string, stubs: StubSources): Promise<Map<string, string>> {
+  const entries = new Map<string, string>();
+
+  for (const [specifier, source] of Object.entries(stubs)) {
+    const fileName = `${specifier.replace(/[^a-zA-Z0-9_-]+/g, "_")}.ts`;
+    const filePath = path.join(tempDir, fileName);
+    await writeFile(filePath, source, "utf8");
+    entries.set(specifier, pathToFileURL(filePath).href);
+  }
+
+  return entries;
+}
+
+function replaceImportSpecifiers(source: string, replacements: Map<string, string>): string {
+  let transformed = source;
+  for (const [specifier, fileUrl] of replacements) {
+    const fromPattern = new RegExp(`from\\s+(["'])${escapeRegExp(specifier)}\\1`, "g");
+    transformed = transformed.replace(fromPattern, `from "${fileUrl}"`);
+    const barePattern = new RegExp(`import\\s+(["'])${escapeRegExp(specifier)}\\1`, "g");
+    transformed = transformed.replace(barePattern, `import "${fileUrl}"`);
+  }
+  return transformed;
+}
+
+async function loadPostPageModule() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), TEMP_PREFIX));
+  const stubEntries = await writeStubModules(tempDir, {
+    "next/cache": `export const unstable_cache = () => async () => (globalThis as any).__mockPost ?? null;`,
+    "next/navigation": `export const notFound = () => { throw new Error('notFound'); };`,
+    "@components/layout": `export const Layout = () => null;`,
+    "@components/back-home": `export const BackHome = () => null;`,
+    "@components/Comment": `const Comment = () => null; export default Comment;`,
+    "@components/PostHeader": `export const PostHeader = () => null;`,
+    "./post-content-client": `const PostContentClient = () => null; export default PostContentClient;`,
+    "../../../lib/renderers/mdx": `export async function renderPostMdx() { return ""; }`,
+    "../../../lib/admin": `export async function resolveAdminStatus() { return { isAdmin: false }; }`,
+    "../../../lib/mongo": `export async function getMongoDb() {
+      return {
+        collection() {
+          return {
+            findOne() {
+              return (globalThis as any).__mockPost ?? null;
+            },
+          };
+        },
+      };
+    }`,
+    remark: `export const remark = () => ({
+      use() {
+        return {
+          process: async () => ({
+            toString: () => "",
+          }),
+        };
+      },
+    });`,
+    "remark-html": `const html = () => null; export default html;`,
+  });
+
+  const absolutePath = path.resolve(process.cwd(), "src/app/posts/[id]/page.tsx");
+  const originalSource = await readFile(absolutePath, "utf8");
+  const transformedSource = replaceImportSpecifiers(originalSource, stubEntries);
+
+  const targetPath = path.join(tempDir, "module-under-test.tsx");
+  await writeFile(targetPath, transformedSource, "utf8");
+
+  const moduleUrl = pathToFileURL(targetPath).href + `?t=${Date.now()}`;
+  return import(moduleUrl);
+}
+
+afterEach(() => {
+  delete globalThis.__mockPost;
+});
+
+test("generateMetadata uses subtitle for description", async () => {
+  globalThis.__mockPost = {
+    postId: "with-subtitle",
+    title: "Post With Subtitle",
+    subtitle: "A concise summary.",
+    date: "2024-01-01T00:00:00.000Z",
+  };
+
+  const module = await loadPostPageModule();
+  const metadata = await module.generateMetadata({
+    params: Promise.resolve({ id: "with-subtitle" }),
+  });
+
+  assert.equal(metadata.description, "A concise summary.");
+  assert.equal(metadata.openGraph?.description, "A concise summary.");
+  assert.equal(metadata.twitter?.description, "A concise summary.");
+});
+
+test("generateMetadata leaves description undefined without subtitle", async () => {
+  globalThis.__mockPost = {
+    postId: "without-subtitle",
+    title: "Post Without Subtitle",
+    date: "2024-01-01T00:00:00.000Z",
+    htmlContent: "<p>This body should not appear in metadata.</p>",
+  };
+
+  const module = await loadPostPageModule();
+  const metadata = await module.generateMetadata({
+    params: Promise.resolve({ id: "without-subtitle" }),
+  });
+
+  assert.equal(metadata.description, undefined);
+  assert.equal(metadata.openGraph?.description, undefined);
+  assert.equal(metadata.twitter?.description, undefined);
+});


### PR DESCRIPTION
## Summary
- derive post metadata descriptions solely from the post subtitle and omit them when no subtitle exists
- add coverage that verifies the new metadata description and social card behavior

## Testing
- npx tsx --test tests/post-metadata.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f24cc3f883228f833bfb35067467)