### PR TITLE
Add scroll progress effect to layout

### DIFF
--- a/components/ScrollProgressEffect.tsx
+++ b/components/ScrollProgressEffect.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+
+function setScrollVariables(progress: number, visible: boolean) {
+  const root = document.documentElement;
+  root.style.setProperty("--scroll-progress", progress.toString());
+  root.style.setProperty("--scroll-progress-visible", visible ? "1" : "0");
+}
+
+export default function ScrollProgressEffect() {
+  useEffect(() => {
+    const container = document.querySelector<HTMLElement>(
+      "[data-scroll-progress-root]"
+    );
+
+    if (!container) {
+      setScrollVariables(0, false);
+      return;
+    }
+
+    let animationFrame = 0;
+
+    const update = () => {
+      animationFrame = 0;
+      const containerTop =
+        container.getBoundingClientRect().top + window.scrollY;
+      const scrollTop = Math.max(0, window.scrollY - containerTop);
+      const totalScrollable = container.scrollHeight - container.clientHeight;
+
+      if (totalScrollable <= 0) {
+        setScrollVariables(0, false);
+        return;
+      }
+
+      const progress = Math.min(
+        1,
+        Math.max(0, scrollTop / totalScrollable)
+      );
+
+      setScrollVariables(progress, true);
+    };
+
+    const requestUpdate = () => {
+      if (animationFrame) return;
+      animationFrame = window.requestAnimationFrame(update);
+    };
+
+    update();
+
+    window.addEventListener("scroll", requestUpdate, { passive: true });
+    window.addEventListener("resize", requestUpdate);
+
+    return () => {
+      window.removeEventListener("scroll", requestUpdate);
+      window.removeEventListener("resize", requestUpdate);
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+      setScrollVariables(0, false);
+    };
+  }, []);
+
+  return null;
+}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import ThemeSwitcher from "./ThemeSwitcher";
 import SettingsMenu from "./SettingsMenu";
+import ScrollProgressEffect from "./ScrollProgressEffect";
 
 type LayoutProps = {
   title?: string;
@@ -11,11 +14,12 @@ type LayoutProps = {
 
 export function Layout({ home = false, children }: LayoutProps) {
   return (
-    <div className="max-w-xl flex flex-col mx-auto px-4 mb-4">
-      <header
-        data-scroll-progress-root
-        className="flex justify-between items-center py-1"
-      >
+    <div
+      data-scroll-progress-root
+      className="max-w-xl flex flex-col mx-auto px-4 mb-4"
+    >
+      <ScrollProgressEffect />
+      <header className="flex justify-between items-center py-1">
         <div aria-hidden="true" data-scroll-progress-bar />
         <ThemeSwitcher /> {/* Botão de brilho à direita */}
         <SettingsMenu /> {/* Botão de três pontos à esquerda */}


### PR DESCRIPTION
## Summary
- add a client-side scroll progress effect that updates CSS variables for the progress bar
- render the effect from the layout component and mark the layout as a client component
- hide the progress bar when the content is shorter than the viewport

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913f57bfa1c8322965ab22db36e947b)