### PR TITLE
Adjust scroll progress formatting and load updates

### DIFF
--- a/components/ScrollProgressEffect.tsx
+++ b/components/ScrollProgressEffect.tsx
@@ -4,7 +4,10 @@ import { useEffect } from "react";
 
 function setScrollVariables(progress: number, visible: boolean) {
   const root = document.documentElement;
-  root.style.setProperty("--scroll-progress", progress.toString());
+  const progressValue = visible
+    ? `${(progress * 100).toFixed(3)}%`
+    : "0%";
+  root.style.setProperty("--scroll-progress", progressValue);
   root.style.setProperty("--scroll-progress-visible", visible ? "1" : "0");
 }
 
@@ -50,13 +53,18 @@ export default function ScrollProgressEffect() {
     };
 
     update();
+    if (document.readyState === "complete") {
+      requestUpdate();
+    }
 
     window.addEventListener("scroll", requestUpdate, { passive: true });
     window.addEventListener("resize", requestUpdate);
+    window.addEventListener("load", requestUpdate);
 
     return () => {
       window.removeEventListener("scroll", requestUpdate);
       window.removeEventListener("resize", requestUpdate);
+      window.removeEventListener("load", requestUpdate);
       if (animationFrame) {
         cancelAnimationFrame(animationFrame);
       }


### PR DESCRIPTION
## Summary
- format the `--scroll-progress` CSS variable as a percentage string and reset it to 0% when hidden
- schedule scroll progress updates on window load using the existing requestUpdate helper
- trigger a deferred update immediately when the document is already loaded

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913fd13c81c832280f7c4720ec3dee4)