### PR TITLE
Lazy load settings and comment widgets

### DIFF
--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -1,26 +1,16 @@
 "use client";
 
-import { useState } from "react";
-import { EllipsisVerticalIcon, XMarkIcon } from "@heroicons/react/20/solid";
-import {
-  useUser,  
-  ClerkProvider,
-  SignInButton,
-  SignedIn,
-  SignedOut,
-  UserButton, 
-} from "@clerk/nextjs";	
+import { SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 
 export default function SettingsMenu() {
-
   return (
-    <div className="">
-                <SignedOut>
-                  <SignInButton />
-                </SignedOut>
-                <SignedIn>
-                  <UserButton />
-                </SignedIn>
+    <div className="flex items-center">
+      <SignedOut>
+        <SignInButton />
+      </SignedOut>
+      <SignedIn>
+        <UserButton />
+      </SignedIn>
     </div>
   );
 }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import ThemeSwitcher from "./ThemeSwitcher";
-import SettingsMenu from "./SettingsMenu";
 import ScrollProgressEffect from "./ScrollProgressEffect";
+
+const SettingsMenu = dynamic(() => import("./SettingsMenu"), {
+  ssr: false,
+  loading: () => <span aria-hidden className="block h-8 w-8" />,
+});
 
 type LayoutProps = {
   title?: string;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -11,6 +11,7 @@
   src: url(./PolySans-Slim.woff2) format('woff2');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 /* Estilo inicial do body (modo escuro por padrão) */


### PR DESCRIPTION
## Summary
- add `font-display: swap` to the PolySans webfont to improve perceived loading
- lazily hydrate the settings menu with a lightweight placeholder while Clerk loads on the client
- defer paragraph comment widgets with an on-demand loader, placeholder paragraphs, and an intersection observer trigger

## Testing
- npm run build *(fails: missing MongoDB/Clerk configuration in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691402c268c883228c4bc2f93c2253a0)