### PR TITLE
Refactor admin editor layout and styling

### DIFF
--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -151,8 +151,7 @@ export default function Editor() {
                         </span>
                       )}
                       <div
-                        name="content"
-                        className="min-h-[420px] w-full bg-transparent px-5 pb-6 pt-4 text-base leading-relaxed text-zinc-100 caret-emerald-400 focus:outline-none font-[\"IAWriterQuattroV-Italic\",serif]"
+                        className='min-h-[420px] w-full bg-transparent px-5 pb-6 pt-4 text-base leading-relaxed text-zinc-100 caret-emerald-400 focus:outline-none font-["IAWriterQuattroV-Italic",serif]'
                         contentEditable
                         suppressContentEditableWarning
                         spellCheck={false}

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -17,6 +17,7 @@ export default function Editor() {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isEditorFocused, setIsEditorFocused] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -77,180 +78,244 @@ export default function Editor() {
   };
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 py-12">
-      <div className="mx-auto max-w-3xl px-6">
-        <header className="mb-8 text-center">
-          <h1 className="text-3xl font-semibold tracking-tight">Novo post</h1>
-          <p className="mt-2 text-sm text-zinc-400">
-            Preencha os campos abaixo para publicar um novo conteÃºdo.
+    <div className="min-h-screen bg-gradient-to-b from-zinc-950 via-zinc-950 to-neutral-900 py-12 text-zinc-100">
+      <div className="mx-auto max-w-6xl px-6">
+        <header className="mb-10 text-center">
+          <p className="text-sm uppercase tracking-[0.2em] text-zinc-500">
+            Painel Editorial
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold tracking-tight text-zinc-50 sm:text-5xl">
+            Novo post
+          </h1>
+          <p className="mt-3 text-base text-zinc-400">
+            Preencha os campos principais e organize os detalhes na barra lateral.
           </p>
         </header>
 
-        <form
-          onSubmit={handleSubmit}
-          className="space-y-6 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-8 shadow-2xl shadow-black/20"
-        >
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-zinc-300">titulo</span>
-              <input
-                name="title"
-                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="Digite o titulo do post"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                required
-              />
-            </label>
-            <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-zinc-300">Subtítulo</span>
-              <input
-                name="subtitle"
-                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="Resumo curto do post"
-                value={subtitle}
-                onChange={(e) => setSubtitle(e.target.value)}
-              />
-            </label>
-            <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-zinc-300">Post ID</span>
-              <input
-                name="postId"
-                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="Identificador único do post"
-                value={postId}
-                onChange={(e) => setPostId(e.target.value)}
-                required
-              />
-            </label>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 shadow-lg shadow-black/30 backdrop-blur">
+                <div className="border-b border-zinc-800/70 px-6 pb-5 pt-6">
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                    Conteúdo principal
+                  </p>
+                  <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium text-zinc-300">Título</span>
+                      <input
+                        name="title"
+                        className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-4 py-2.5 text-sm text-zinc-50 placeholder:text-zinc-600 transition focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                        type="text"
+                        placeholder="Digite o título do post"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        required
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium text-zinc-300">Subtítulo</span>
+                      <input
+                        name="subtitle"
+                        className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-4 py-2.5 text-sm text-zinc-50 placeholder:text-zinc-600 transition focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                        type="text"
+                        placeholder="Resumo curto do post"
+                        value={subtitle}
+                        onChange={(e) => setSubtitle(e.target.value)}
+                      />
+                    </label>
+                  </div>
+                </div>
+
+                <div className="px-6 pb-8 pt-5">
+                  <div className="flex items-baseline justify-between gap-4">
+                    <div>
+                      <p className="text-lg font-semibold text-zinc-100">Editor</p>
+                      <p className="text-sm text-zinc-500">
+                        Bloco com estilo obsidiano para manter o foco na escrita.
+                      </p>
+                    </div>
+                    <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200">
+                      Canvas
+                    </span>
+                  </div>
+
+                  <div className="mt-5 rounded-xl border border-zinc-800/80 bg-gradient-to-b from-zinc-950 via-zinc-950 to-zinc-900 shadow-[0_20px_60px_-35px_rgba(0,0,0,0.8)]">
+                    <label className="block px-4 pb-2 pt-4 text-sm font-medium text-zinc-300">
+                      Conteúdo
+                    </label>
+                    <div className="relative overflow-hidden rounded-b-xl border-t border-zinc-800/80 bg-zinc-950/80">
+                      {!content && !isEditorFocused && (
+                        <span className="pointer-events-none absolute left-5 top-4 text-sm text-zinc-600">
+                          Insira o conteúdo do post...
+                        </span>
+                      )}
+                      <div
+                        name="content"
+                        className="min-h-[420px] w-full bg-transparent px-5 pb-6 pt-4 text-base leading-relaxed text-zinc-100 caret-emerald-400 focus:outline-none font-[\"IAWriterQuattroV-Italic\",serif]"
+                        contentEditable
+                        suppressContentEditableWarning
+                        spellCheck={false}
+                        onFocus={() => setIsEditorFocused(true)}
+                        onBlur={() => setIsEditorFocused(false)}
+                        onInput={(e) => setContent((e.target as HTMLDivElement).innerHTML)}
+                        dangerouslySetInnerHTML={{ __html: content }}
+                        aria-label="Área principal de conteúdo"
+                      />
+                      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-black/40 to-transparent" />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <aside className="space-y-4 lg:sticky lg:top-8">
+              <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 p-5 shadow-md shadow-black/30">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-zinc-200">Visibilidade</p>
+                  <span className="text-xs uppercase tracking-[0.18em] text-zinc-500">Meta</span>
+                </div>
+                <div className="mt-4 space-y-3 divide-y divide-zinc-800/70">
+                  <label className="flex items-start gap-3 pt-1 text-sm text-zinc-200">
+                    <input
+                      type="checkbox"
+                      id="hidden"
+                      checked={hidden}
+                      onChange={(e) => setHidden(e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-zinc-700 bg-zinc-950 text-emerald-400 focus:ring-emerald-500"
+                    />
+                    <span className="leading-5">Ocultar post nas listagens públicas</span>
+                  </label>
+                  <label
+                    htmlFor="paragraph-comments"
+                    className="flex items-start gap-3 pt-3 text-sm text-zinc-200"
+                  >
+                    <input
+                      type="checkbox"
+                      id="paragraph-comments"
+                      checked={paragraphCommentsEnabled}
+                      onChange={(e) => setParagraphCommentsEnabled(e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-zinc-700 bg-zinc-950 text-emerald-400 focus:ring-emerald-500"
+                    />
+                    <span className="leading-5">Permitir comentários por parágrafo</span>
+                  </label>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 p-5 shadow-md shadow-black/30">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-zinc-200">Midia & tags</p>
+                  <span className="text-xs uppercase tracking-[0.18em] text-zinc-500">Detalhes</span>
+                </div>
+                <div className="mt-4 space-y-4">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500">Capa</span>
+                    <input
+                      name="cape"
+                      className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                      type="text"
+                      placeholder="URL da imagem de capa"
+                      value={cape}
+                      onChange={(e) => setCape(e.target.value)}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-2">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500">Foto do amigo</span>
+                    <input
+                      name="friendImage"
+                      className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                      type="text"
+                      placeholder="URL da foto do amigo"
+                      value={friendImage}
+                      onChange={(e) => setFriendImage(e.target.value)}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-2">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500">Tags</span>
+                    <input
+                      name="tags"
+                      className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                      type="text"
+                      placeholder="separe por vírgulas"
+                      value={tags}
+                      onChange={(e) => setTags(e.target.value)}
+                    />
+                  </label>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 p-5 shadow-md shadow-black/30">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-zinc-200">Áudio</p>
+                  <span className="text-xs uppercase tracking-[0.18em] text-zinc-500">Opcional</span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  <label className="flex items-center justify-between gap-3 text-sm text-zinc-200">
+                    <span>Este post possui áudio?</span>
+                    <input
+                      type="checkbox"
+                      id="hasAudio"
+                      checked={hasAudio}
+                      onChange={(e) => setHasAudio(e.target.checked)}
+                      className="h-4 w-4 rounded border-zinc-700 bg-zinc-950 text-emerald-400 focus:ring-emerald-500"
+                    />
+                  </label>
+                  {hasAudio && (
+                    <input
+                      name="audioUrl"
+                      className="w-full rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                      type="text"
+                      placeholder="URL do Áudio"
+                      value={audioUrl}
+                      onChange={(e) => setAudioUrl(e.target.value)}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 p-5 shadow-md shadow-black/30">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-zinc-200">Publicação</p>
+                  <span className="text-xs uppercase tracking-[0.18em] text-zinc-500">Controle</span>
+                </div>
+                <div className="mt-4 space-y-4">
+                  <label className="flex flex-col gap-2">
+                    <span className="text-xs uppercase tracking-wide text-zinc-500">Post ID</span>
+                    <input
+                      name="postId"
+                      className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:border-emerald-500/70 focus:outline-none focus:ring-2 focus:ring-emerald-500/30"
+                      type="text"
+                      placeholder="Identificador único do post"
+                      value={postId}
+                      onChange={(e) => setPostId(e.target.value)}
+                      required
+                    />
+                  </label>
+
+                  <button
+                    type="submit"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-emerald-500 to-emerald-400 px-4 py-3 text-sm font-semibold text-zinc-950 shadow-lg shadow-emerald-500/20 transition hover:from-emerald-400 hover:to-emerald-300 disabled:cursor-not-allowed disabled:opacity-70"
+                    disabled={isSubmitting}
+                  >
+                    {isSubmitting ? "Publicando..." : "Publicar post"}
+                  </button>
+                </div>
+              </div>
+            </aside>
           </div>
-          <div className="flex items-center rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-3">
-            <label htmlFor="hidden" className="flex items-center gap-3 text-sm">
-              <input
-                type="checkbox"
-                id="hidden"
-                checked={hidden}
-                onChange={(e) => setHidden(e.target.checked)}
-                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-500"
-              />
-              Ocultar post (não aparecer em listagens públicas)
-            </label>
-          </div>
 
-          <div className="flex items-center rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-3">
-            <label
-              htmlFor="paragraph-comments"
-              className="flex items-center justify-between gap-3 w-full text-sm"
-            >
-              <span>Permitir comentários por parágrafo</span>
-              <input
-                type="checkbox"
-                id="paragraph-comments"
-                checked={paragraphCommentsEnabled}
-                onChange={(e) => setParagraphCommentsEnabled(e.target.checked)}
-                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-500"
-              />
-            </label>
-          </div>
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-zinc-300">Capa</span>
-              <input
-                name="cape"
-                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="URL da imagem de capa"
-                value={cape}
-                onChange={(e) => setCape(e.target.value)}
-              />
-            </label>
-            <label className="flex flex-col gap-2">
-              <span className="text-sm font-medium text-zinc-300">Foto do amigo</span>
-              <input
-                name="friendImage"
-                className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="URL da foto do amigo"
-                value={friendImage}
-                onChange={(e) => setFriendImage(e.target.value)}
-              />
-            </label>
-          </div>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-sm font-medium text-zinc-300">Tags</span>
-            <input
-              name="tags"
-              className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-              type="text"
-              placeholder="separe por vírgulas"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-            />
-          </label>
-
-          <div className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-3">
-            <label htmlFor="hasAudio" className="flex items-center gap-3 text-sm">
-              <input
-                type="checkbox"
-                id="hasAudio"
-                checked={hasAudio}
-                onChange={(e) => setHasAudio(e.target.checked)}
-                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-zinc-100 focus:ring-zinc-500"
-              />
-              Este post possui Áudio?
-            </label>
-            {hasAudio && (
-              <input
-                name="audioUrl"
-                className="w-full max-w-xs rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-                type="text"
-                placeholder="URL do Audio"
-                value={audioUrl}
-                onChange={(e) => setAudioUrl(e.target.value)}
-              />
-            )}
-          </div>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-sm font-medium text-zinc-300">ConteÃºdo</span>
-            <textarea
-              name="content"
-              className="min-h-[260px] rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3 text-sm leading-relaxed text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-500/40"
-              placeholder="Insira o conteudo do Post"
-              spellCheck="false"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              required
-            />
-          </label>
-
-          <button
-            type="submit"
-            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-zinc-100 px-4 py-3 text-sm font-semibold text-zinc-900 transition hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={isSubmitting}
-          >
-            {isSubmitting ? "Publicando..." : "Publicar post"}
-          </button>
-
-          {success && (
-            <p className="text-center text-sm font-medium text-green-400">
-              {success}
-            </p>
-          )}
-          {error && (
-            <p className="text-center text-sm font-medium text-red-400">{error}</p>
+          {(success || error) && (
+            <div className="rounded-2xl border border-zinc-800/70 bg-zinc-900/70 p-4 text-center shadow-md shadow-black/30">
+              {success && (
+                <p className="text-sm font-medium text-emerald-400">{success}</p>
+              )}
+              {error && (
+                <p className="text-sm font-medium text-red-400">{error}</p>
+              )}
+            </div>
           )}
         </form>
       </div>
     </div>
   );
 }
-
-
-
-


### PR DESCRIPTION
## Summary
- restyle the admin editor with a full-width background, centered container, and elevated typography
- introduce a two-column layout with an obsidian-inspired content canvas and contenteditable rich editor
- move supporting fields into stacked sidebar cards with refined inputs and a Ghost-like publish CTA

## Testing
- npm run lint *(fails: script not found)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e49618dfc8322b0389ca9f14b78b0)