### PR TITLE
Improve Lexical editor integration and add live preview

### DIFF
--- a/components/editor/LexicalEditor.tsx
+++ b/components/editor/LexicalEditor.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
@@ -9,10 +15,52 @@ import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { CLEAR_EDITOR_COMMAND, EditorState } from "lexical";
+import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import {
+  CLEAR_EDITOR_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  EditorState,
+  FORMAT_TEXT_COMMAND,
+  KEY_DOWN_COMMAND,
+  SELECTION_CHANGE_COMMAND,
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+} from "lexical";
+import {
+  INSERT_UNORDERED_LIST_COMMAND,
+} from "@lexical/list";
+import { TOGGLE_LINK_COMMAND } from "@lexical/link";
+import { LinkNode } from "@lexical/link";
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+  TRANSFORMERS,
+} from "@lexical/markdown";
+import {
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  $createHeadingNode,
+  $createQuoteNode,
+} from "@lexical/rich-text";
+import { CodeNode, $createCodeNode } from "@lexical/code";
+import { mergeRegister } from "@lexical/utils";
 
 const theme = {
   paragraph: "mb-1 leading-relaxed text-[15px] text-zinc-100",
+  quote:
+    "my-3 border-l-2 border-emerald-500/40 pl-3 text-[15px] text-zinc-200 italic",
+  list: {
+    listitem: "ml-4 text-[15px] text-zinc-100 marker:text-emerald-400",
+  },
+  heading: {
+    h1: "text-2xl font-semibold text-zinc-50",
+    h2: "text-xl font-semibold text-zinc-100",
+    h3: "text-lg font-semibold text-zinc-100",
+  },
   text: {
     bold: "font-semibold text-zinc-50",
     italic: "italic text-zinc-100",
@@ -34,6 +82,203 @@ interface LexicalEditorProps {
   onFocusChange?: (isFocused: boolean) => void;
 }
 
+const ToolbarButton = ({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="rounded-lg px-2 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:bg-white/5 hover:text-emerald-200"
+  >
+    {label}
+  </button>
+);
+
+function Toolbar() {
+  const [editor] = useLexicalComposerContext();
+
+  const formatHeading = useCallback(
+    () =>
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        const anchorNode = selection.anchor.getNode();
+        const element = anchorNode.getTopLevelElementOrThrow();
+        if (element.getType() === "heading") {
+          const paragraph = $createParagraphNode();
+          paragraph.append(...element.getChildren());
+          element.replace(paragraph);
+        } else {
+          const heading = $createHeadingNode("h2");
+          heading.append(...element.getChildren());
+          element.replace(heading);
+        }
+      }),
+    [editor]
+  );
+
+  const toggleList = useCallback(() => {
+    editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
+  }, [editor]);
+
+  const toggleQuote = useCallback(
+    () =>
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        const anchorNode = selection.anchor.getNode();
+        const element = anchorNode.getTopLevelElementOrThrow();
+        if (element.getType() === "quote") {
+          const paragraph = $createParagraphNode();
+          paragraph.append(...element.getChildren());
+          element.replace(paragraph);
+        } else {
+          const quote = $createQuoteNode();
+          quote.append(...element.getChildren());
+          element.replace(quote);
+        }
+      }),
+    [editor]
+  );
+
+  const toggleCode = useCallback(
+    () =>
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        const anchorNode = selection.anchor.getNode();
+        const element = anchorNode.getTopLevelElementOrThrow();
+        if (element.getType() === "code") {
+          const paragraph = $createParagraphNode();
+          paragraph.append(...element.getChildren());
+          element.replace(paragraph);
+        } else {
+          const code = $createCodeNode();
+          code.append(...element.getChildren());
+          element.replace(code);
+        }
+      }),
+    [editor]
+  );
+
+  const toggleLink = useCallback(() => {
+    editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+  }, [editor]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-xl border border-white/5 bg-white/[0.04] px-3 py-2 text-xs shadow-inner shadow-black/40">
+      <ToolbarButton
+        label="Bold"
+        onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "bold")}
+      />
+      <ToolbarButton
+        label="Italic"
+        onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, "italic")}
+      />
+      <ToolbarButton label="Heading" onClick={formatHeading} />
+      <ToolbarButton label="Lista" onClick={toggleList} />
+      <ToolbarButton label="Code" onClick={toggleCode} />
+      <ToolbarButton label="Quote" onClick={toggleQuote} />
+      <ToolbarButton label="Link" onClick={toggleLink} />
+    </div>
+  );
+}
+
+function SlashMenu({
+  onInsert,
+}: {
+  onInsert: (label: string) => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+  const [isOpen, setIsOpen] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const insertText = useCallback(
+    (text: string) => {
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(text);
+        }
+      });
+    },
+    [editor]
+  );
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        KEY_DOWN_COMMAND,
+        (event) => {
+          if (event.key === "/") {
+            setIsOpen(true);
+            const selection = window.getSelection();
+            if (selection && selection.rangeCount > 0) {
+              setAnchorRect(selection.getRangeAt(0).getBoundingClientRect());
+            }
+          } else if (event.key === "Escape") {
+            setIsOpen(false);
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW
+      ),
+      editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => {
+          const selection = window.getSelection();
+          if (selection && selection.rangeCount > 0) {
+            setAnchorRect(selection.getRangeAt(0).getBoundingClientRect());
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW
+      ),
+      editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          const selection = $getSelection();
+          if (!selection || selection.isCollapsed() === false) return;
+          const anchorNode = selection.anchor.getNode();
+          const textContent = anchorNode.getTextContent();
+          if (!textContent.endsWith("/")) {
+            setIsOpen(false);
+          }
+        });
+      })
+    );
+  }, [editor]);
+
+  const options = ["@autor", "@co-autor", "Referência de post"];
+
+  if (!isOpen || !anchorRect) return null;
+
+  return (
+    <div
+      className="fixed z-20 w-48 overflow-hidden rounded-xl border border-white/10 bg-[#0d1118] p-2 shadow-2xl shadow-black/50"
+      style={{ top: anchorRect.bottom + 6, left: anchorRect.left }}
+    >
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => {
+            insertText(option + " ");
+            onInsert(option);
+            setIsOpen(false);
+          }}
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-zinc-200 transition hover:bg-white/5 hover:text-emerald-200"
+        >
+          <span className="text-emerald-300">/</span> {option}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function ResetOnEmpty({ value }: { value: string }) {
   const [editor] = useLexicalComposerContext();
 
@@ -51,6 +296,9 @@ export default function LexicalEditor({
   onChange,
   onFocusChange,
 }: LexicalEditorProps) {
+  const handleSlashInsert = useCallback((option: string) => {
+    console.info("Slash menu option:", option);
+  }, []);
   const initialValueRef = useRef(value);
   const initialConfig = useMemo(
     () => ({
@@ -59,15 +307,24 @@ export default function LexicalEditor({
       onError: (error: Error) => {
         console.error(error);
       },
-      editorState: initialValueRef.current || undefined,
+      nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, CodeNode, LinkNode],
+      editorState: (editor) => {
+        const markdown = initialValueRef.current;
+        if (!markdown) return;
+        editor.update(() => {
+          $convertFromMarkdownString(markdown, TRANSFORMERS);
+        });
+      },
     }),
     []
   );
 
   const handleChange = useCallback(
     (editorState: EditorState) => {
-      const json = editorState.toJSON();
-      onChange(JSON.stringify(json));
+      editorState.read(() => {
+        const markdown = $convertToMarkdownString(TRANSFORMERS);
+        onChange(markdown);
+      });
     },
     [onChange]
   );
@@ -75,21 +332,29 @@ export default function LexicalEditor({
   return (
     <LexicalComposer initialConfig={initialConfig}>
       <div className="relative overflow-hidden rounded-2xl border border-white/5 bg-gradient-to-b from-[#0b0d12] via-[#0d1016] to-[#0a0c11] shadow-[0_30px_80px_-60px_rgba(0,0,0,0.9)]">
-        <RichTextPlugin
-          contentEditable={
-            <ContentEditable
-              className='min-h-[350px] w-full bg-transparent px-4 pb-6 pt-4 text-base leading-relaxed text-zinc-100 caret-emerald-400 focus:outline-none font-["IAWriterQuattroV-Italic",serif]'
-              aria-label="Área principal de conteúdo"
-              spellCheck={false}
-              onFocus={() => onFocusChange?.(true)}
-              onBlur={() => onFocusChange?.(false)}
-            />
-          }
-          placeholder={<Placeholder />}
-          ErrorBoundary={LexicalErrorBoundary}
-        />
+        <div className="border-b border-white/5 px-4 pb-3 pt-4">
+          <Toolbar />
+        </div>
+        <div className="relative">
+          <RichTextPlugin
+            contentEditable={
+              <ContentEditable
+                className='min-h-[350px] w-full bg-transparent px-4 pb-6 pt-4 text-base leading-relaxed text-zinc-100 caret-emerald-400 focus:outline-none font-["IAWriterQuattroV-Italic",serif]'
+                aria-label="Área principal de conteúdo"
+                spellCheck={false}
+                onFocus={() => onFocusChange?.(true)}
+                onBlur={() => onFocusChange?.(false)}
+              />
+            }
+            placeholder={<Placeholder />}
+            ErrorBoundary={LexicalErrorBoundary}
+          />
+          <SlashMenu onInsert={handleSlashInsert} />
+        </div>
         <HistoryPlugin />
         <AutoFocusPlugin />
+        <ListPlugin />
+        <LinkPlugin />
         <OnChangePlugin onChange={handleChange} />
         <ResetOnEmpty value={value} />
       </div>

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import DOMPurify from "dompurify";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import remarkHtml from "remark-html";
 
 import LexicalEditor from "../../../../components/editor/LexicalEditor";
 import Toggle from "../../../../components/Toggle";
@@ -17,6 +21,7 @@ export default function Editor() {
   const [hidden, setHidden] = useState(false);
   const [paragraphCommentsEnabled, setParagraphCommentsEnabled] = useState(true);
   const [content, setContent] = useState("");
+  const [previewHtml, setPreviewHtml] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -90,6 +95,19 @@ export default function Editor() {
   const handleContentChange = (value: string) => {
     setContent(value);
   };
+
+  useEffect(() => {
+    const convert = async () => {
+      const processed = await remark()
+        .use(remarkGfm)
+        .use(remarkHtml)
+        .process(content || "");
+
+      setPreviewHtml(DOMPurify.sanitize(String(processed)));
+    };
+
+    convert();
+  }, [content]);
 
   const editorBorder = useMemo(
     () =>
@@ -170,6 +188,26 @@ export default function Editor() {
                       onFocusChange={setIsEditorFocused}
                     />
                   </div>
+                </div>
+
+                <div className="mt-4 rounded-2xl border border-white/5 bg-white/[0.02] p-4 shadow-inner shadow-black/30">
+                  <div className="mb-3 flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-zinc-200">Preview</p>
+                      <p className={hintText}>Renderização em tempo real em Markdown.</p>
+                    </div>
+                    <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200">
+                      Live
+                    </span>
+                  </div>
+                  <div
+                    className="min-h-[160px] space-y-3 rounded-xl border border-white/5 bg-black/20 px-4 py-3 text-sm leading-relaxed text-zinc-100"
+                    dangerouslySetInnerHTML={{
+                      __html:
+                        previewHtml ||
+                        "<p class='text-zinc-500'>Nada para pré-visualizar ainda.</p>",
+                    }}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- integrate Lexical with markdown-aware onChange handling, toolbar controls, and slash command menu options
- hydrate the editor from existing markdown while keeping reset behavior consistent
- add a live markdown preview panel below the editor on the admin page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5529f2048322a70760f9be194399)