### PR TITLE
Disable post page prefetching from home list

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -195,6 +195,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
             <li key={post.postId} className="flex flex-col mb-2 group relative">
               <Link
                 href={`/posts/${post.postId}`}
+                prefetch={false}
                 className="text-xl hover:underline"
               >
                 {post.title}


### PR DESCRIPTION
## Summary
- disable Next.js prefetching for post links on the home list to avoid eager loading heavy post content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920924fc0b48322954e7ff1a85f74a6)