### PR TITLE
Add volume controls and polish audio player thumb

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -1,6 +1,6 @@
 "use client"; // Marca como Client Component
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { PlayIcon, PauseIcon } from "@heroicons/react/20/solid";
 
 // Props do componente AudioPlayer
@@ -18,9 +18,15 @@ function formatTime(seconds: number): string {
 export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
   // Estados para o player de áudio
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const gainNodeRef = useRef<GainNode | null>(null);
+  const sourceRef = useRef<MediaElementAudioSourceNode | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const boostLevels = useMemo(() => [1, 1.5, 2], []);
+  const [boostIndex, setBoostIndex] = useState(0);
 
   // Funções para controlar o áudio
   const togglePlayPause = () => {
@@ -28,6 +34,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
       if (isPlaying) {
         audioRef.current.pause();
       } else {
+        audioContextRef.current?.resume();
         audioRef.current.play();
       }
       setIsPlaying(!isPlaying);
@@ -54,6 +61,55 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
     }
   };
 
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newVolume = Number(e.target.value);
+    setVolume(newVolume);
+  };
+
+  const handleBoostToggle = () => {
+    setBoostIndex((prev) => (prev + 1) % boostLevels.length);
+  };
+
+  useEffect(() => {
+    if (!audioRef.current || typeof window === "undefined") return;
+
+    if (!audioContextRef.current) {
+      const AudioContextClass =
+        window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+
+      if (!AudioContextClass) return;
+
+      const context = new AudioContextClass();
+      const source = context.createMediaElementSource(audioRef.current);
+      const gainNode = context.createGain();
+
+      source.connect(gainNode);
+      gainNode.connect(context.destination);
+
+      audioContextRef.current = context;
+      gainNodeRef.current = gainNode;
+      sourceRef.current = source;
+    }
+  }, [audioUrl]);
+
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = volume;
+    }
+
+    if (gainNodeRef.current) {
+      gainNodeRef.current.gain.value = volume * boostLevels[boostIndex];
+    }
+  }, [volume, boostIndex, boostLevels]);
+
+  useEffect(() => {
+    return () => {
+      sourceRef.current?.disconnect();
+      gainNodeRef.current?.disconnect();
+      audioContextRef.current?.close();
+    };
+  }, []);
+
   return (
     <div className="w-full max-w-2xl mx-auto rounded-lg shadow-md flex
                     items-center gap-4">
@@ -63,6 +119,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
         src={audioUrl}
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={handleLoadedMetadata}
+        onEnded={() => setIsPlaying(false)}
         className="hidden"
       />
 
@@ -92,7 +149,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
           max={duration || 0}
           value={currentTime}
           onChange={handleSeek}
-          className="w-full h-2 rounded-full appearance-none cursor-pointer"
+          className="w-full h-2 rounded-full appearance-none cursor-pointer progress-thumb"
           style={{
             background: `linear-gradient(to right, #0F0F0F ${
               (currentTime / duration) * 100
@@ -100,6 +157,65 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
           }}
         />
       </div>
+
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-zinc-600 dark:text-zinc-400" htmlFor="volume-slider">
+          Volume
+        </label>
+        <input
+          id="volume-slider"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={volume}
+          onChange={handleVolumeChange}
+          className="w-24 h-2 rounded-full appearance-none cursor-pointer"
+        />
+      </div>
+
+      <button
+        onClick={handleBoostToggle}
+        className="text-xs font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white rounded px-2 py-1 border border-zinc-200 dark:border-zinc-700"
+      >
+        Boost x{boostLevels[boostIndex].toFixed(1)}
+      </button>
+
+      <style jsx>{`
+        .progress-thumb::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          height: 14px;
+          width: 14px;
+          border-radius: 9999px;
+          background: #f4f4f5;
+          border: 2px solid #0f0f0f;
+          box-shadow: 0 0 0 6px rgba(15, 15, 15, 0.08);
+        }
+
+        .progress-thumb::-moz-range-thumb {
+          height: 14px;
+          width: 14px;
+          border-radius: 9999px;
+          background: #f4f4f5;
+          border: 2px solid #0f0f0f;
+          box-shadow: 0 0 0 6px rgba(15, 15, 15, 0.08);
+        }
+
+        @media (prefers-color-scheme: dark) {
+          .progress-thumb::-webkit-slider-thumb {
+            background: #0f0f0f;
+            border-color: #e4e4e7;
+            box-shadow: 0 0 0 6px rgba(228, 228, 231, 0.12);
+          }
+
+          .progress-thumb::-moz-range-thumb {
+            background: #0f0f0f;
+            border-color: #e4e4e7;
+            box-shadow: 0 0 0 6px rgba(228, 228, 231, 0.12);
+          }
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add volume slider and boost toggle while keeping existing playback logic intact
- enhance progress thumb styling with rounded highlight to match current design
- ensure playback state resets to play icon when audio ends

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209eb9c1e883229431746cdaae07f8)