### PR TITLE
Fix audio context routing to avoid double playback

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -86,6 +86,8 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
       source.connect(gainNode);
       gainNode.connect(context.destination);
 
+      audioRef.current.muted = true;
+
       audioContextRef.current = context;
       gainNodeRef.current = gainNode;
       sourceRef.current = source;
@@ -93,17 +95,18 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
   }, [audioUrl]);
 
   useEffect(() => {
-    if (audioRef.current) {
-      audioRef.current.volume = volume;
-    }
-
     if (gainNodeRef.current) {
       gainNodeRef.current.gain.value = volume * boostLevels[boostIndex];
+    } else if (audioRef.current) {
+      audioRef.current.volume = volume;
     }
   }, [volume, boostIndex, boostLevels]);
 
   useEffect(() => {
     return () => {
+      if (audioRef.current) {
+        audioRef.current.muted = false;
+      }
       sourceRef.current?.disconnect();
       gainNodeRef.current?.disconnect();
       audioContextRef.current?.close();


### PR DESCRIPTION
## Summary
- mute the media element when routed through the Web Audio graph to prevent duplicate playback
- apply volume changes through the gain node when AudioContext is available and keep element volume for fallback
- restore element mute state on cleanup when tearing down the audio graph

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a10ac5b48322ad1cf82d95fcc9e0)