### PR TITLE
Fix multiline className in audio player

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -111,8 +111,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
   }, []);
 
   return (
-    <div className="w-full max-w-2xl mx-auto rounded-lg shadow-md flex
-                    items-center gap-4">
+    <div className={`w-full max-w-2xl mx-auto rounded-lg shadow-md flex items-center gap-4`}>
       {/* Elemento de áudio oculto para controle */}
       <audio
         ref={audioRef}


### PR DESCRIPTION
## Summary
- replace the multiline className on the audio player container with a single template literal
- ensure the audio player layout classes are defined in one line for proper JSX parsing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a2f754b88322834e948e416c3dc0)