### PR TITLE
Add crossOrigin to audio player element

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -116,6 +116,7 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
       <audio
         ref={audioRef}
         src={audioUrl}
+        crossOrigin="anonymous"
         onTimeUpdate={handleTimeUpdate}
         onLoadedMetadata={handleLoadedMetadata}
         onEnded={() => setIsPlaying(false)}


### PR DESCRIPTION
## Summary
- add crossOrigin="anonymous" to the audio element to allow Web Audio processing without CORS errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a6a2d884832280074edb92728f0f)