### PR TITLE
Simplify audio boost and update slider styling

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -1,7 +1,9 @@
 "use client"; // Marca como Client Component
 
-import { useState, useRef, useEffect, useMemo } from "react";
-import { PlayIcon, PauseIcon } from "@heroicons/react/20/solid";
+import { useState, useRef, useEffect } from "react";
+import { PlayIcon, PauseIcon, BoltIcon } from "@heroicons/react/20/solid";
+
+const BOOST_MULTIPLIER = 2;
 
 // Props do componente AudioPlayer
 type AudioPlayerProps = {
@@ -25,8 +27,6 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [volume, setVolume] = useState(1);
-  const boostLevels = useMemo(() => [1, 1.5, 2], []);
-  const [boostIndex, setBoostIndex] = useState(0);
 
   // Funções para controlar o áudio
   const togglePlayPause = () => {
@@ -66,10 +66,6 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
     setVolume(newVolume);
   };
 
-  const handleBoostToggle = () => {
-    setBoostIndex((prev) => (prev + 1) % boostLevels.length);
-  };
-
   useEffect(() => {
     if (!audioRef.current || typeof window === "undefined") return;
 
@@ -98,9 +94,9 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
     }
 
     if (gainNodeRef.current) {
-      gainNodeRef.current.gain.value = volume * boostLevels[boostIndex];
+      gainNodeRef.current.gain.value = volume * BOOST_MULTIPLIER;
     }
-  }, [volume, boostIndex, boostLevels]);
+  }, [volume]);
 
   useEffect(() => {
     return () => {
@@ -149,11 +145,11 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
           max={duration || 0}
           value={currentTime}
           onChange={handleSeek}
-          className="w-full h-2 rounded-full appearance-none cursor-pointer progress-thumb"
+          className="w-full h-2 rounded-full appearance-none cursor-pointer bg-zinc-200 dark:bg-zinc-700 progress-thumb"
           style={{
             background: `linear-gradient(to right, #0F0F0F ${
-              (currentTime / duration) * 100
-            }%, #1F1F1F ${(currentTime / duration) * 100}%)`,
+              duration ? (currentTime / duration) * 100 : 0
+            }%, #d4d4d8 ${duration ? (currentTime / duration) * 100 : 0}%)`,
           }}
         />
       </div>
@@ -175,44 +171,38 @@ export default function AudioPlayer({ audioUrl }: AudioPlayerProps) {
       </div>
 
       <button
-        onClick={handleBoostToggle}
+        type="button"
         className="text-xs font-medium text-zinc-700 hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-white rounded px-2 py-1 border border-zinc-200 dark:border-zinc-700"
+        aria-label="Volume boost at 2x gain"
+        title="Volume boost at 2x gain"
       >
-        Boost x{boostLevels[boostIndex].toFixed(1)}
+        <BoltIcon className="h-4 w-4" aria-hidden="true" />
       </button>
 
       <style jsx>{`
         .progress-thumb::-webkit-slider-thumb {
           -webkit-appearance: none;
           appearance: none;
-          height: 14px;
-          width: 14px;
+          height: 12px;
+          width: 12px;
           border-radius: 9999px;
-          background: #f4f4f5;
-          border: 2px solid #0f0f0f;
-          box-shadow: 0 0 0 6px rgba(15, 15, 15, 0.08);
+          background: #27272a;
         }
 
         .progress-thumb::-moz-range-thumb {
-          height: 14px;
-          width: 14px;
+          height: 12px;
+          width: 12px;
           border-radius: 9999px;
-          background: #f4f4f5;
-          border: 2px solid #0f0f0f;
-          box-shadow: 0 0 0 6px rgba(15, 15, 15, 0.08);
+          background: #27272a;
         }
 
         @media (prefers-color-scheme: dark) {
           .progress-thumb::-webkit-slider-thumb {
-            background: #0f0f0f;
-            border-color: #e4e4e7;
-            box-shadow: 0 0 0 6px rgba(228, 228, 231, 0.12);
+            background: #e4e4e7;
           }
 
           .progress-thumb::-moz-range-thumb {
-            background: #0f0f0f;
-            border-color: #e4e4e7;
-            box-shadow: 0 0 0 6px rgba(228, 228, 231, 0.12);
+            background: #e4e4e7;
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary
- replace boost cycling with a fixed 2x gain multiplier and a lightning icon indicator with updated accessibility labels
- ensure gain handling uses the static multiplier when applying volume changes
- simplify the progress slider thumb styling to a minimal solid circle to mimic the default player knob

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a9825fec83228220cd3875b2e9b0)