### PR TITLE
Fix heroicon import path for audio player

### DIFF
--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { PlayIcon, PauseIcon, BoltIcon as BoltSolidIcon } from "@heroicons/react/20/solid";
-import { BoltIcon as BoltOutlineIcon } from "@heroicons/react/20/outline";
+import { BoltIcon as BoltOutlineIcon } from "@heroicons/react/24/outline";
 
 const BOOST_MULTIPLIER = 2;
 


### PR DESCRIPTION
## Summary
- fix the AudioPlayer outline icon import to use the available 24px heroicon path

## Testing
- CI=1 npm run build
  - fails: missing required environment variables MONGODB_URI and MONGODB_DB during build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920abf56fb4832286dfdd9ab44e7c4d)