### PR TITLE
Fix slash menu key type

### DIFF
--- a/components/editor/LexicalEditor.tsx
+++ b/components/editor/LexicalEditor.tsx
@@ -269,7 +269,7 @@ function SlashMenu({
     >
       {options.map((option) => (
         <button
-          key={option}
+          key={option.token}
           type="button"
           onClick={() => {
             insertText(option.token + " ");


### PR DESCRIPTION
## Summary
- set slash menu button keys to use token values to satisfy React key typing

## Testing
- CI=1 npm run build -- --turbopack

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ce4edbf48322a6690443734cc585)