### PR TITLE
Refactor admin editor into post layout

### DIFF
--- a/components/editor/LexicalEditor.tsx
+++ b/components/editor/LexicalEditor.tsx
@@ -77,6 +77,7 @@ interface LexicalEditorProps {
   value: string;
   onChange: (value: string) => void;
   onFocusChange?: (isFocused: boolean) => void;
+  appearance?: "panel" | "inline";
 }
 
 const ToolbarButton = ({
@@ -339,6 +340,7 @@ export default function LexicalEditor({
   value,
   onChange,
   onFocusChange,
+  appearance = "panel",
 }: LexicalEditorProps) {
   const handleSlashInsert = useCallback(() => {
     // No-op placeholder for future telemetry
@@ -386,7 +388,16 @@ export default function LexicalEditor({
 
   return (
     <LexicalComposer initialConfig={initialConfig}>
-      <div className="relative overflow-hidden rounded-2xl border border-white/5 bg-gradient-to-b from-[#0b0d12] via-[#0d1016] to-[#0a0c11] shadow-[0_30px_80px_-60px_rgba(0,0,0,0.9)]">
+      <div
+        className={[
+          "relative overflow-hidden",
+          appearance === "panel"
+            ? "rounded-2xl border border-white/5 bg-gradient-to-b from-[#0b0d12] via-[#0d1016] to-[#0a0c11] shadow-[0_30px_80px_-60px_rgba(0,0,0,0.9)]"
+            : "rounded-xl border border-white/10 bg-transparent backdrop-blur",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
         <div className="border-b border-white/5 px-4 pb-3 pt-4">
           <Toolbar />
         </div>

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Layout } from "@components/layout";
-import BackHome from "@components/back-home";
+import { BackHome } from "@components/back-home";
 import LexicalEditor from "../../../../components/editor/LexicalEditor";
 import Toggle from "../../../../components/Toggle";
 import PostContentShell from "../../posts/[id]/post-content-interactive";

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -233,6 +233,8 @@ type PostContentShellProps = {
   initialViews: number;
   audioUrl?: string;
   children: ReactNode;
+  disableViewTracking?: boolean;
+  hideShareButton?: boolean;
 };
 
 export default function PostContentShell({
@@ -242,6 +244,8 @@ export default function PostContentShell({
   initialViews,
   audioUrl,
   children,
+  disableViewTracking = false,
+  hideShareButton = false,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const [isMobile, setIsMobile] = useState(false);
@@ -264,6 +268,10 @@ export default function PostContentShell({
   }, []);
 
   useEffect(() => {
+    if (disableViewTracking) {
+      return () => {};
+    }
+
     let canceled = false;
 
     const trackView = async () => {
@@ -286,7 +294,7 @@ export default function PostContentShell({
     return () => {
       canceled = true;
     };
-  }, [postId]);
+  }, [disableViewTracking, postId]);
 
   const headerCounters = useMemo(
     () => (
@@ -313,12 +321,12 @@ export default function PostContentShell({
           </div>
 
           <span className="justify-self-end">
-            <ShareButton id={postId} />
+            {!hideShareButton && <ShareButton id={postId} />}
           </span>
         </div>
       </div>
     ),
-    [date, postId, readingTime, views],
+    [date, hideShareButton, postId, readingTime, views],
   );
 
   return (


### PR DESCRIPTION
## Summary
- rework the admin post editor to reuse the public post layout with inline title, subtitle, and content editing
- move post metadata and publishing controls into a compact drawer while keeping minimap and rich text styling intact
- add inline styling option for the Lexical editor and optional view/share controls for post content shell

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e5f5cbf0832292859e3a529726e9)