### PR TITLE
Refactor admin editor to mirror post layout

### DIFF
--- a/components/PostHeader.tsx
+++ b/components/PostHeader.tsx
@@ -1,5 +1,6 @@
-"use client"
+"use client";
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -9,13 +10,36 @@ type PostHeaderProps = {
   subtitle?: string; // Subtítulo opcional
   friendImage?: string; // Link opcional para a foto do amigo
   coAuthorImageUrl?: string | null;
+  titleSlot?: ReactNode;
+  subtitleSlot?: ReactNode;
+  disableProfileLinks?: boolean;
+  overlaySlot?: ReactNode;
 };
 
-export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUrl }: PostHeaderProps) {
+export function PostHeader({
+  cape,
+  title,
+  subtitle,
+  friendImage,
+  coAuthorImageUrl,
+  titleSlot,
+  subtitleSlot,
+  disableProfileLinks = false,
+  overlaySlot,
+}: PostHeaderProps) {
   const secondaryImage = coAuthorImageUrl || friendImage || undefined;
+
+  const AvatarWrapper = ({ children }: { children: ReactNode }) => {
+    if (disableProfileLinks) {
+      return <div className="pointer-events-none">{children}</div>;
+    }
+
+    return <Link href="/">{children}</Link>;
+  };
 
   return (
     <div className="w-full relative">
+      {overlaySlot}
       {cape && (
         <div className="w-full relative">
           <Image
@@ -33,7 +57,7 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
             </div>
             <div className="absolute bottom-1 left-2 lg:bottom-3 flex flex-col gap-2">
               <div className="flex -space-x-5">
-                <Link href="/">
+                <AvatarWrapper>
                   <Image
                     priority
                     src="/images/profile.jpg"
@@ -42,9 +66,9 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
                     width={56}
                     alt="Domenyk"
                   />
-                </Link>
+                </AvatarWrapper>
                 {secondaryImage && (
-                  <Link href="/">
+                  <AvatarWrapper>
                     <Image
                       src={secondaryImage}
                       className="foto-post hover:z-30 transition-all"
@@ -52,13 +76,11 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
                       width={56}
                       alt="Amigo"
                     />
-                  </Link>
+                  </AvatarWrapper>
                 )}
               </div>
-              <h1 className="text-xl text-white">{title}</h1>
-              {subtitle ? (
-                <p className="text-sm text-zinc-200 drop-shadow">{subtitle}</p>
-              ) : null}
+              {titleSlot ?? <h1 className="text-xl text-white">{title}</h1>}
+              {subtitleSlot ?? (subtitle ? <p className="text-sm text-zinc-200 drop-shadow">{subtitle}</p> : null)}
             </div>
           </div>
         </div>
@@ -66,7 +88,7 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
       {!cape && (
         <div className="flex flex-col gap-4 items-center">
           <div className="flex -space-x-4">
-            <Link href="/">
+            <AvatarWrapper>
               <Image
                 priority
                 src="/images/profile.jpg"
@@ -75,9 +97,9 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
                 width={148}
                 alt="Domenyk"
               />
-            </Link>
+            </AvatarWrapper>
             {secondaryImage && (
-              <Link href="/">
+              <AvatarWrapper>
                 <Image
                   src={secondaryImage}
                   className="rounded-full brightness-125 foto"
@@ -85,11 +107,11 @@ export function PostHeader({ cape, title, subtitle, friendImage, coAuthorImageUr
                   width={148}
                   alt="Amigo"
                 />
-              </Link>
+              </AvatarWrapper>
             )}
           </div>
-          <h1 className=" ">{title}</h1>
-          {subtitle ? <p className="text-sm text-zinc-300 text-center">{subtitle}</p> : null}
+          {titleSlot ?? <h1 className=" ">{title}</h1>}
+          {subtitleSlot ?? (subtitle ? <p className="text-sm text-zinc-300 text-center">{subtitle}</p> : null)}
         </div>
       )}
     </div>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -15,9 +15,10 @@ type LayoutProps = {
   url?: string;
   home?: boolean;
   children: React.ReactNode;
+  hideHeaderControls?: boolean;
 };
 
-export function Layout({ home = false, children }: LayoutProps) {
+export function Layout({ home = false, children, hideHeaderControls = false }: LayoutProps) {
   return (
     <div
       data-scroll-progress-root
@@ -26,8 +27,16 @@ export function Layout({ home = false, children }: LayoutProps) {
       <ScrollProgressEffect />
       <header className="flex justify-between items-center py-1">
         <div aria-hidden="true" data-scroll-progress-bar />
-        <ThemeSwitcher /> {/* Botão de brilho à direita */}
-        <SettingsMenu /> {/* Botão de três pontos à esquerda */}
+        {hideHeaderControls ? (
+          <span aria-hidden className="h-8 w-8" />
+        ) : (
+          <ThemeSwitcher />
+        )}
+        {hideHeaderControls ? (
+          <span aria-hidden className="h-8 w-8" />
+        ) : (
+          <SettingsMenu />
+        )}
       </header>
       <main className={`${home ? "home" : ""} flex flex-col flex-1`}>
         {children}

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -235,6 +235,7 @@ type PostContentShellProps = {
   children: ReactNode;
   disableViewTracking?: boolean;
   hideShareButton?: boolean;
+  secondaryHeaderSlot?: ReactNode;
 };
 
 export default function PostContentShell({
@@ -246,6 +247,7 @@ export default function PostContentShell({
   children,
   disableViewTracking = false,
   hideShareButton = false,
+  secondaryHeaderSlot,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const [isMobile, setIsMobile] = useState(false);
@@ -334,6 +336,8 @@ export default function PostContentShell({
       <div className="relative flex flex-col gap-6">
         <article className="flex flex-col gap-6 mt-4">
           {headerCounters}
+
+          {secondaryHeaderSlot}
 
           {audioUrl && <AudioPlayer audioUrl={audioUrl} />}
 


### PR DESCRIPTION
## Summary
- hide global chrome when rendering the admin editor and extend the post header to accept editable slots and overlays
- add optional secondary header slot on post content shell to surface preview badges and slug information
- redesign the admin editor page to reuse the public post layout while keeping live editable fields and metadata controls

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921eaccfab48322a427d6b88a371a04)