### PR TITLE
Use markdownContent as primary field and remove code fence wrappers

### DIFF
--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -7,6 +7,7 @@ import { PostHeader } from "@components/PostHeader";
 import LexicalEditor from "../../../../components/editor/LexicalEditor";
 import Toggle from "../../../../components/Toggle";
 import PostContentShell from "../../posts/[id]/post-content-interactive";
+import { normalizeMarkdownContent } from "../../../lib/markdown-normalize";
 
 function calculateReadingTime(markdown: string): string {
   const wordsPerMinute = 200;
@@ -271,7 +272,9 @@ export default function Editor() {
       nextErrors.postId = "Post ID é obrigatório.";
     }
 
-    if (!content.trim()) {
+    const sanitizedContent = normalizeMarkdownContent(content);
+
+    if (!sanitizedContent.trim()) {
       nextErrors.content = "Escreva algo antes de publicar.";
     }
 
@@ -310,7 +313,9 @@ export default function Editor() {
       formData.append("title", title);
       formData.append("subtitle", subtitle);
       formData.append("postId", postId);
-      formData.append("contentMarkdown", content);
+      const normalizedContent = normalizeMarkdownContent(content);
+
+      formData.append("markdownContent", normalizedContent);
       formData.append("tags", tags);
       formData.append("cape", cape);
       if (friendImage) {
@@ -364,7 +369,8 @@ export default function Editor() {
   const handleContentChange = (value: string) => {
     clearFieldError("content");
     markDirty();
-    setContent(value);
+    const normalizedValue = normalizeMarkdownContent(value);
+    setContent(normalizedValue);
   };
 
   const editorBorder = useMemo(

--- a/src/lib/markdown-normalize.ts
+++ b/src/lib/markdown-normalize.ts
@@ -1,0 +1,15 @@
+export function normalizeMarkdownContent(markdown: string): string {
+  if (typeof markdown !== "string") {
+    return "";
+  }
+
+  const trimmed = markdown.trim();
+  const fencePattern = /^```(?:[a-zA-Z0-9+-]*)?\r?\n([\s\S]*?)\r?\n```$/;
+  const match = trimmed.match(fencePattern);
+
+  if (match) {
+    return match[1];
+  }
+
+  return markdown;
+}


### PR DESCRIPTION
## Summary
- add a shared normalizer to strip full-document code fences from markdown
- update the admin editor and API to send/save markdownContent only and validate empty content after normalization
- prefer markdownContent when rendering posts, normalizing it before description and HTML rendering while falling back to legacy htmlContent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f012bb8c8322968f4e63131de90e)