### PR TITLE
Make home post metadata clickable

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -196,16 +196,16 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
               <Link
                 href={`/posts/${post.postId}`}
                 prefetch={false}
-                className="text-xl hover:underline"
+                className="flex flex-col text-left"
               >
-                {post.title}
+                <span className="text-xl hover:underline">{post.title}</span>
+                <small className="text-zinc-600 dark:text-zinc-300">
+                  <Date dateString={post.date} /> <span aria-hidden className="mx-2">&middot;</span>
+                  <span className="inline-flex items-center rounded px-2 py-1 text-sm text-zinc-600 dark:text-zinc-300">
+                    {post.views ?? 0} views
+                  </span>
+                </small>
               </Link>
-              <small className="text-zinc-600 dark:text-zinc-300">
-                <Date dateString={post.date} /> <span aria-hidden className="mx-2">&middot;</span>
-                <span className="inline-flex items-center rounded px-2 py-1 text-sm text-zinc-600 dark:text-zinc-300">
-                  {post.views ?? 0} views
-                </span>
-              </small>
               {isAdmin && (
                 <button
                   onClick={() => openDeleteModal(post.postId)}


### PR DESCRIPTION
## Summary
- wrap the home page post title, date, and views in a single link to enlarge the clickable area without visual changes
- keep existing spacing outside the link so the gap between posts remains non-clickable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b5ab056c832282b881f561ca7df5)