### PR TITLE
Add admin edit mode to post page

### DIFF
--- a/src/app/api/posts/[id]/edit/route.ts
+++ b/src/app/api/posts/[id]/edit/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { clientPromise } from "../../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../../lib/admin";
+
+export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const params = await context.params;
+  const id = params?.id;
+
+  if (!id || typeof id !== "string") {
+    return NextResponse.json({ error: "Post ID é obrigatório." }, { status: 400 });
+  }
+
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Acesso negado." }, { status: 403 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Corpo da requisição inválido." }, { status: 400 });
+  }
+
+  const { title, subtitle, htmlContent, markdownContent } =
+    (payload as Partial<Record<string, unknown>>) ?? {};
+
+  const updateDocument: Record<string, unknown> = {};
+
+  if (typeof title === "string") {
+    updateDocument.title = title;
+  }
+
+  if (typeof subtitle === "string") {
+    updateDocument.subtitle = subtitle;
+  }
+
+  if (typeof htmlContent === "string") {
+    updateDocument.htmlContent = htmlContent;
+    updateDocument.content = htmlContent;
+  }
+
+  if (typeof markdownContent === "string") {
+    const trimmedMarkdown = markdownContent.trim();
+    updateDocument.markdownContent = trimmedMarkdown;
+    updateDocument.contentMarkdown = trimmedMarkdown;
+  }
+
+  if (Object.keys(updateDocument).length === 0) {
+    return NextResponse.json({ error: "Nenhum campo válido para atualizar." }, { status: 400 });
+  }
+
+  updateDocument.updatedAt = new Date().toISOString();
+
+  try {
+    const client = await clientPromise;
+    const db = client.db("blog");
+    const collection = db.collection("posts");
+
+    const result = await collection.updateOne({ postId: id }, { $set: updateDocument });
+
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        htmlContent: updateDocument.htmlContent,
+        markdownContent: updateDocument.markdownContent,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Erro ao atualizar post:", error);
+    return NextResponse.json({ error: "Erro interno ao atualizar post." }, { status: 500 });
+  }
+}

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -236,6 +236,7 @@ type PostContentShellProps = {
   disableViewTracking?: boolean;
   hideShareButton?: boolean;
   secondaryHeaderSlot?: ReactNode;
+  footerSlot?: ReactNode;
 };
 
 export default function PostContentShell({
@@ -248,6 +249,7 @@ export default function PostContentShell({
   disableViewTracking = false,
   hideShareButton = false,
   secondaryHeaderSlot,
+  footerSlot,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const [isMobile, setIsMobile] = useState(false);
@@ -344,6 +346,8 @@ export default function PostContentShell({
           <div data-post-content className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs">
             {children}
           </div>
+
+          {footerSlot ? <div className="mt-2 flex flex-col gap-2">{footerSlot}</div> : null}
 
           {/* <Chatbot htmlContent={htmlContent} /> */}
         </article>


### PR DESCRIPTION
## Summary
- add an admin-only inline edit mode to post pages with a discreet toggle and save flow
- keep post content visually consistent while allowing contentEditable editing and cancel/save feedback
- introduce a protected `/api/posts/[id]/edit` route that enforces Clerk admin access before updating MongoDB content

## Testing
- `npm run lint` *(fails: script not defined in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924b7d8f22c8322b987a597dd5863df)