### PR TITLE
Add editing flag to post content shell

### DIFF
--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -509,6 +509,7 @@ export default function Editor() {
           audioUrl={audioSource}
           disableViewTracking
           hideShareButton
+          isEditing
           secondaryHeaderSlot={
             <div className="flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -236,6 +236,7 @@ type PostContentShellProps = {
   disableViewTracking?: boolean;
   hideShareButton?: boolean;
   secondaryHeaderSlot?: ReactNode;
+  isEditing?: boolean;
 };
 
 export default function PostContentShell({
@@ -248,6 +249,7 @@ export default function PostContentShell({
   disableViewTracking = false,
   hideShareButton = false,
   secondaryHeaderSlot,
+  isEditing = false,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const [isMobile, setIsMobile] = useState(false);
@@ -341,7 +343,12 @@ export default function PostContentShell({
 
           {audioUrl && <AudioPlayer audioUrl={audioUrl} />}
 
-          <div data-post-content className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs">
+          <div
+            data-post-content
+            className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs"
+            contentEditable={isEditing || undefined}
+            suppressContentEditableWarning
+          >
             {children}
           </div>
 


### PR DESCRIPTION
## Summary
- add an optional `isEditing` flag to `PostContentShell` to control inline content editing
- pass the editing flag from the admin editor page so inline mode enables content editing affordances

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c0100fd88322ad2ebee3a73124a2)