### PR TITLE
Add admin edit link to post page

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,6 +1,7 @@
 ﻿import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { unstable_cache } from "next/cache";
+import Link from "next/link";
 import { Layout } from "@components/layout";
 import { BackHome } from "@components/back-home";
 import Comment from "@components/Comment";
@@ -403,6 +404,17 @@ export default async function PostPage({ params }: PostPageProps) {
         isAdmin={isAdmin}
       />
       <BackHome />
+      {isAdmin && (
+        <div className="mt-4 sm:mt-6 mb-2">
+          <Link
+            href={`/admin/editor?postId=${encodeURIComponent(post.postId)}`}
+            className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:bg-purple-500 dark:hover:bg-purple-400"
+            aria-label={`Editar post ${title ? `"${title}"` : "atual"}`}
+          >
+            <span className="leading-none">Editar post</span>
+          </Link>
+        </div>
+      )}
       <div className="mt-4 sm:mt-6 mb-6">
         <Comment
           postId={post.postId}


### PR DESCRIPTION
## Summary
- add an admin-only edit shortcut linking to the editor with the current post id
- place the control near the comments section with CTA styling and accessibility labels

## Testing
- npm run lint *(fails: Missing script "lint" in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c2d07904832288bfb034af945832)