### PR TITLE
Add inline post editing with API patch endpoint

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,5 +1,10 @@
 import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { defaultDependencies, resolvePostResponse } from "./handler";
+import { renderPostMdx } from "../../../../lib/renderers/mdx";
+import { renderMarkdown } from "../../../../lib/renderers/markdown";
+import { normalizeMarkdownContent } from "../../../../lib/markdown-normalize";
+import { resolveAdminStatus } from "../../../../lib/admin";
 
 export async function GET(
   req: NextRequest,
@@ -7,4 +12,97 @@ export async function GET(
 ) {
   const params = await context.params;
   return resolvePostResponse(req, params, defaultDependencies);
+}
+
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const params = await context.params;
+  const postId = params?.id;
+
+  if (!postId || typeof postId !== "string") {
+    return NextResponse.json(
+      { error: "Post ID is required and must be a string" },
+      { status: 400 }
+    );
+  }
+
+  const { isAdmin } = await resolveAdminStatus();
+
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
+  }
+
+  let markdownContent: string | null = null;
+
+  try {
+    const body = (await req.json()) as { markdownContent?: unknown };
+    if (typeof body?.markdownContent !== "string") {
+      return NextResponse.json(
+        { error: "markdownContent is required and must be a string" },
+        { status: 400 }
+      );
+    }
+    markdownContent = normalizeMarkdownContent(body.markdownContent);
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  if (!markdownContent || markdownContent.trim() === "") {
+    return NextResponse.json(
+      { error: "markdownContent must not be empty" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { getMongoDb } = await import("../../../../lib/mongo");
+    const db = await getMongoDb();
+    const postsCollection = db.collection("posts");
+
+    const result = await postsCollection.updateOne(
+      { postId },
+      {
+        $set: {
+          markdownContent,
+          contentMarkdown: markdownContent,
+          updatedAt: new Date(),
+        },
+      }
+    );
+
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    const shouldUseMdxRenderer = process.env.FEATURE_MDX_RENDERER === "true";
+    let htmlContent: string;
+
+    if (shouldUseMdxRenderer) {
+      try {
+        htmlContent = await renderPostMdx(markdownContent);
+      } catch (error) {
+        console.error(`MDX renderer failed for post ${postId}:`, error);
+        htmlContent = await renderMarkdown(markdownContent);
+      }
+    } else {
+      htmlContent = await renderMarkdown(markdownContent);
+    }
+
+    return NextResponse.json({
+      markdownContent,
+      htmlContent,
+      updatedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Failed to update post content", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -1,12 +1,9 @@
 ﻿import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { unstable_cache } from "next/cache";
-import Link from "next/link";
 import { Layout } from "@components/layout";
-import { BackHome } from "@components/back-home";
-import Comment from "@components/Comment";
 import { PostHeader } from "@components/PostHeader";
-import PostContentClient from "./post-content-client";
+import PostEditingClient from "./post-editing-client";
 import { renderPostMdx } from "../../../lib/renderers/mdx";
 import { resolveAdminStatus } from "../../../lib/admin";
 import { renderMarkdown } from "../../../lib/renderers/markdown";
@@ -391,10 +388,11 @@ export default async function PostPage({ params }: PostPageProps) {
         friendImage={post.friendImage}
         coAuthorImageUrl={coAuthorImageUrl}
       />
-      <PostContentClient
+      <PostEditingClient
         postId={post.postId}
+        title={title}
         date={dateString}
-        htmlContent={htmlContent}
+        initialHtmlContent={htmlContent}
         initialViews={views}
         audioUrl={post.audioUrl}
         readingTime={readingTime}
@@ -402,26 +400,8 @@ export default async function PostPage({ params }: PostPageProps) {
         coAuthorImageUrl={coAuthorImageUrl || post.friendImage || null}
         paragraphCommentsEnabled={paragraphCommentsEnabled}
         isAdmin={isAdmin}
+        initialMarkdown={markdownSource}
       />
-      <BackHome />
-      {isAdmin && (
-        <div className="mt-4 sm:mt-6 mb-2">
-          <Link
-            href={`/admin/editor?postId=${encodeURIComponent(post.postId)}`}
-            className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:bg-purple-500 dark:hover:bg-purple-400"
-            aria-label={`Editar post ${title ? `"${title}"` : "atual"}`}
-          >
-            <span className="leading-none">Editar post</span>
-          </Link>
-        </div>
-      )}
-      <div className="mt-4 sm:mt-6 mb-6">
-        <Comment
-          postId={post.postId}
-          coAuthorUserId={post.coAuthorUserId ?? undefined}
-          isAdmin={isAdmin}
-        />
-      </div>
     </Layout>
   );
 }

--- a/src/app/posts/[id]/post-editing-client.tsx
+++ b/src/app/posts/[id]/post-editing-client.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { BackHome } from "@components/back-home";
+import Comment from "@components/Comment";
+
+import PostContentClient from "./post-content-client";
+
+type LexicalEditorModule = typeof import("../../../../components/editor/LexicalEditor");
+
+export type PostEditingClientProps = {
+  postId: string;
+  title: string;
+  date: string;
+  initialHtmlContent: string;
+  initialViews: number;
+  audioUrl?: string;
+  readingTime: string;
+  coAuthorUserId?: string | null;
+  coAuthorImageUrl?: string | null;
+  paragraphCommentsEnabled: boolean;
+  isAdmin: boolean;
+  initialMarkdown: string;
+};
+
+export default function PostEditingClient({
+  postId,
+  title,
+  date,
+  initialHtmlContent,
+  initialViews,
+  audioUrl,
+  readingTime,
+  coAuthorUserId,
+  coAuthorImageUrl,
+  paragraphCommentsEnabled,
+  isAdmin,
+  initialMarkdown,
+}: PostEditingClientProps) {
+  const [LexicalEditor, setLexicalEditor] = useState<
+    LexicalEditorModule["default"] | null
+  >(null);
+  const [editorLoadError, setEditorLoadError] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [markdownValue, setMarkdownValue] = useState(initialMarkdown);
+  const [lastSavedMarkdown, setLastSavedMarkdown] = useState(initialMarkdown);
+  const [htmlContent, setHtmlContent] = useState(initialHtmlContent);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    import("../../../../components/editor/LexicalEditor")
+      .then((mod) => setLexicalEditor(() => mod.default))
+      .catch((error) => {
+        console.error("Failed to load inline editor", error);
+        setEditorLoadError(true);
+      });
+  }, []);
+
+  const editorActions = useMemo(() => {
+    if (editorLoadError) {
+      return null;
+    }
+
+    if (!isEditing) {
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            if (!LexicalEditor) {
+              setEditorLoadError(true);
+              return;
+            }
+            setSaveError(null);
+            setIsEditing(true);
+          }}
+          className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:bg-purple-500 dark:hover:bg-purple-400"
+          aria-label={`Editar post ${title ? `"${title}"` : "atual"}`}
+        >
+          <span className="leading-none">Editar post</span>
+        </button>
+      );
+    }
+
+    if (!LexicalEditor) {
+      return (
+        <div className="rounded-xl border border-zinc-800/70 bg-zinc-950/70 p-4 text-sm text-zinc-200">
+          Carregando editor...
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-3 rounded-2xl border border-white/10 bg-zinc-950/80 p-4">
+        <LexicalEditor
+          value={markdownValue}
+          onChange={setMarkdownValue}
+          appearance="inline"
+        />
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <button
+            type="button"
+            onClick={async () => {
+              setSaveError(null);
+              setIsSaving(true);
+              try {
+                const response = await fetch(`/api/posts/${postId}`, {
+                  method: "PATCH",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ markdownContent: markdownValue }),
+                });
+
+                if (!response.ok) {
+                  const payload = (await response.json().catch(() => null)) as
+                    | { error?: string }
+                    | null;
+                  throw new Error(payload?.error || "Falha ao salvar alterações");
+                }
+
+                const payload = (await response.json()) as {
+                  htmlContent?: string;
+                  markdownContent?: string;
+                };
+
+                if (typeof payload.markdownContent === "string") {
+                  setMarkdownValue(payload.markdownContent);
+                  setLastSavedMarkdown(payload.markdownContent);
+                }
+                if (typeof payload.htmlContent === "string") {
+                  setHtmlContent(payload.htmlContent);
+                }
+
+                setIsEditing(false);
+              } catch (error) {
+                console.error(error);
+                setSaveError(
+                  error instanceof Error ? error.message : "Erro ao salvar"
+                );
+              } finally {
+                setIsSaving(false);
+              }
+            }}
+            disabled={isSaving}
+            className="inline-flex items-center rounded-full bg-emerald-500 px-4 py-2 font-semibold text-emerald-950 transition hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isSaving ? "Salvando..." : "Salvar alterações"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setMarkdownValue(lastSavedMarkdown);
+              setIsEditing(false);
+              setSaveError(null);
+            }}
+            className="inline-flex items-center rounded-full border border-zinc-700 px-4 py-2 font-semibold text-zinc-200 transition hover:border-zinc-500 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500"
+          >
+            Cancelar
+          </button>
+          {saveError && (
+            <span className="text-sm font-medium text-red-400">{saveError}</span>
+          )}
+        </div>
+      </div>
+    );
+  }, [
+    LexicalEditor,
+    editorLoadError,
+    isEditing,
+    isSaving,
+    lastSavedMarkdown,
+    markdownValue,
+    postId,
+    title,
+    saveError,
+  ]);
+
+  return (
+    <>
+      <PostContentClient
+        postId={postId}
+        date={date}
+        htmlContent={htmlContent}
+        initialViews={initialViews}
+        audioUrl={audioUrl}
+        readingTime={readingTime}
+        coAuthorUserId={coAuthorUserId}
+        coAuthorImageUrl={coAuthorImageUrl}
+        paragraphCommentsEnabled={paragraphCommentsEnabled}
+        isAdmin={isAdmin}
+      />
+      <BackHome />
+      {isAdmin && (
+        <div className="mt-4 sm:mt-6 mb-2">
+          {editorLoadError ? (
+            <Link
+              href={`/admin/editor?postId=${encodeURIComponent(postId)}`}
+              className="inline-flex items-center gap-2 rounded-full bg-purple-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-purple-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 dark:bg-purple-500 dark:hover:bg-purple-400"
+              aria-label={`Editar post ${title ? `"${title}"` : "atual"}`}
+            >
+              <span className="leading-none">Editar post</span>
+            </Link>
+          ) : (
+            editorActions
+          )}
+        </div>
+      )}
+      <div className="mt-4 sm:mt-6 mb-6">
+        <Comment
+          postId={postId}
+          coAuthorUserId={coAuthorUserId ?? undefined}
+          isAdmin={isAdmin}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a PATCH handler for `/api/posts/[id]` so admins can update markdown content and receive rendered HTML
- add a client inline editing experience on post pages with save/cancel actions and graceful fallback to the admin editor
- wire the post page to refresh content after inline edits using the new client component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c82ff7608322870251c93f269a1d)