### PR TITLE
Enable inline editing for post page

### DIFF
--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -11,7 +11,7 @@ import PostContentShell, {
   LazyParagraphCommentWidget,
   type ParagraphCommentWidgetProps,
 } from "./post-content-interactive";
-import type { HTMLAttributes } from "react";
+import type { HTMLAttributes, RefObject } from "react";
 
 function renderParagraphWithComments(
   node: Element,
@@ -74,6 +74,8 @@ type PostContentClientProps = {
   coAuthorImageUrl?: string | null;
   paragraphCommentsEnabled: boolean;
   isAdmin: boolean;
+  isEditing?: boolean;
+  contentRef?: RefObject<HTMLDivElement>;
 };
 
 export default function PostContentClient({
@@ -87,6 +89,8 @@ export default function PostContentClient({
   coAuthorImageUrl,
   paragraphCommentsEnabled,
   isAdmin,
+  isEditing = false,
+  contentRef,
 }: PostContentClientProps) {
   let paragraphIndex = 0;
 
@@ -115,7 +119,7 @@ export default function PostContentClient({
       }
     }
 
-    if (node.type === "tag" && node.name === "p" && paragraphCommentsEnabled) {
+    if (node.type === "tag" && node.name === "p" && paragraphCommentsEnabled && !isEditing) {
       const element = node as Element;
       const currentIndex = paragraphIndex;
       paragraphIndex += 1;
@@ -144,6 +148,8 @@ export default function PostContentClient({
       readingTime={readingTime}
       initialViews={initialViews}
       audioUrl={audioUrl}
+      isEditing={isEditing}
+      contentRef={contentRef}
     >
       {parsedContent}
     </PostContentShell>

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -75,7 +75,7 @@ type PostContentClientProps = {
   paragraphCommentsEnabled: boolean;
   isAdmin: boolean;
   isEditing?: boolean;
-  contentRef?: RefObject<HTMLDivElement>;
+  contentRef?: RefObject<HTMLDivElement | null>;
 };
 
 export default function PostContentClient({

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -238,7 +238,7 @@ type PostContentShellProps = {
   hideShareButton?: boolean;
   secondaryHeaderSlot?: ReactNode;
   isEditing?: boolean;
-  contentRef?: RefObject<HTMLDivElement>;
+  contentRef?: RefObject<HTMLDivElement | null>;
 };
 
 export default function PostContentShell({

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -15,6 +15,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 import { Date } from "@components/date";
 import ShareButton from "@components/ShareButton";
@@ -237,6 +238,7 @@ type PostContentShellProps = {
   hideShareButton?: boolean;
   secondaryHeaderSlot?: ReactNode;
   isEditing?: boolean;
+  contentRef?: RefObject<HTMLDivElement>;
 };
 
 export default function PostContentShell({
@@ -250,6 +252,7 @@ export default function PostContentShell({
   hideShareButton = false,
   secondaryHeaderSlot,
   isEditing = false,
+  contentRef,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const [isMobile, setIsMobile] = useState(false);
@@ -348,6 +351,7 @@ export default function PostContentShell({
             className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs"
             contentEditable={isEditing || undefined}
             suppressContentEditableWarning
+            ref={contentRef}
           >
             {children}
           </div>


### PR DESCRIPTION
## Summary
- remove the separate Lexical editor from the post detail view
- allow admins to toggle inline editing on the rendered post content while keeping the existing layout
- serialize inline edits back to markdown before saving and return to read-only mode

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ceb51bb48322b236ddf46d341ca7)