### PR TITLE
Regenerate sitemaps when generation fails

### DIFF
--- a/src/lib/sitemaps.ts
+++ b/src/lib/sitemaps.ts
@@ -298,11 +298,6 @@ export async function readOrGenerateSitemap(kind: "index" | "posts" | "posts-aud
     tags: path.join(SITEMAPS_DIR, "tags.xml"),
   } as const;
 
-  const existing = await readSitemap(filenames[kind]);
-  if (existing) {
-    return existing;
-  }
-
   try {
     const generated = await generateAllSitemaps();
     const value =
@@ -318,6 +313,11 @@ export async function readOrGenerateSitemap(kind: "index" | "posts" | "posts-aud
     }
   } catch (error) {
     console.error("Failed to generate sitemap; returning fallback", error);
+
+    const existing = await readSitemap(filenames[kind]);
+    if (existing) {
+      return existing;
+    }
 
     const fallback =
       {


### PR DESCRIPTION
## Summary
- always attempt to regenerate sitemaps instead of serving potentially stale files
- fall back to existing or empty sitemaps only when regeneration fails

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d84f19508322a4558fc2a911dc65)