### PR TITLE
Fix posts sitemap entries

### DIFF
--- a/src/app/sitemaps/posts.xml/route.ts
+++ b/src/app/sitemaps/posts.xml/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { readOrGenerateSitemap } from "@lib/sitemaps";
 
-// Lists the home page and all posts with thumbnails and realistic changefreq.
+// Lists all public posts with thumbnails and realistic changefreq.
 export async function GET() {
   const xml = await readOrGenerateSitemap("posts");
   if (!xml) {

--- a/src/lib/sitemaps.ts
+++ b/src/lib/sitemaps.ts
@@ -115,39 +115,24 @@ function changefreqForPost(lastModified: Date): "weekly" | "monthly" {
 }
 
 function createPostsXml(posts: PostForSitemap[]): string {
-  const homeLastModified = posts.reduce<Date | null>((latest, post) => {
-    if (!latest || post.lastModified.getTime() > latest.getTime()) {
-      return post.lastModified;
-    }
-    return latest;
-  }, null);
+  const urls = posts.map((post) => {
+    const changefreq = changefreqForPost(post.lastModified);
+    const postSlug = encodeURIComponent(post.postId);
+    const imageBlock =
+      post.thumbnailUrl !== null
+        ? [`  <image:image>`, `    <image:loc>${escapeXml(post.thumbnailUrl)}</image:loc>`, `  </image:image>`]
+        : [];
 
-  const urls = [
-    `<url>`,
-    `  <loc>${BASE_URL}</loc>`,
-    `  <lastmod>${(homeLastModified ?? new Date()).toISOString()}</lastmod>`,
-    `  <changefreq>daily</changefreq>`,
-    `  <priority>1</priority>`,
-    `</url>`,
-    ...posts.map((post) => {
-      const changefreq = changefreqForPost(post.lastModified);
-      const postSlug = encodeURIComponent(post.postId);
-      const imageBlock =
-        post.thumbnailUrl !== null
-          ? [`  <image:image>`, `    <image:loc>${escapeXml(post.thumbnailUrl)}</image:loc>`, `  </image:image>`]
-          : [];
-
-      return [
-        `<url>`,
-        `  <loc>${BASE_URL}/posts/${postSlug}</loc>`,
-        `  <lastmod>${post.lastModified.toISOString()}</lastmod>`,
-        `  <changefreq>${changefreq}</changefreq>`,
-        `  <priority>0.8</priority>`,
-        ...imageBlock,
-        `</url>`,
-      ].join("\n");
-    }),
-  ];
+    return [
+      `<url>`,
+      `  <loc>${BASE_URL}/posts/${postSlug}</loc>`,
+      `  <lastmod>${post.lastModified.toISOString()}</lastmod>`,
+      `  <changefreq>${changefreq}</changefreq>`,
+      `  <priority>0.8</priority>`,
+      ...imageBlock,
+      `</url>`,
+    ].join("\n");
+  });
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
## Summary
- remove the home URL from the posts sitemap and emit only posts
- keep post entries with proper metadata including thumbnails and change frequency
- document the posts sitemap route to reflect the updated content

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925dac8b7748322aa499e29b4c11fa7)