### PR TITLE
Improve sitemap post normalization and logging

### DIFF
--- a/src/lib/sitemaps.ts
+++ b/src/lib/sitemaps.ts
@@ -66,7 +66,7 @@ function resolveThumbnail(raw: RawPost): string | null {
 }
 
 function normalizePost(raw: RawPost): PostForSitemap | null {
-  const id = raw.postId ?? raw.slug ?? (raw._id ? String(raw._id) : null);
+  const id = raw.postId ?? raw.slug ?? raw._id;
 
   if (!id) {
     console.warn("[sitemap] skipping post without id: %s", JSON.stringify(raw));
@@ -112,6 +112,10 @@ async function fetchPublicPosts(): Promise<PostForSitemap[]> {
     })
     .sort({ date: -1 })
     .toArray();
+
+  if (posts.length === 0) {
+    console.error(`[sitemap] no posts returned from DB query (count: ${posts.length})`);
+  }
 
   console.log(`[sitemap] raw posts from DB: ${posts.length}`);
 


### PR DESCRIPTION
## Summary
- normalize sitemap posts using available identifiers before discarding them
- add logging when no posts are returned from the database for easier debugging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e11b98908322bb3f31601c6ed56d)