### PR TITLE
Use contentMarkdown as canonical post content

### DIFF
--- a/src/app/admin/api/editor/route.ts
+++ b/src/app/admin/api/editor/route.ts
@@ -18,10 +18,7 @@ export async function POST(req: Request) {
     const title = formData.get("title");
     const subtitle = formData.get("subtitle");
     const postId = formData.get("postId");
-    const content =
-      formData.get("markdownContent") ??
-      formData.get("contentMarkdown") ??
-      formData.get("content");
+    const content = formData.get("contentMarkdown") ?? formData.get("content");
     const tags = formData.get("tags");
     const audioUrl = formData.get("audioUrl");
     const cape = formData.get("cape");
@@ -120,7 +117,7 @@ export async function POST(req: Request) {
       postId,
       title,
       subtitle: normalizedSubtitle,
-      markdownContent: normalizedContent,
+      contentMarkdown: normalizedContent,
       date: new Date().toISOString().split("T")[0], // Formato "YYYY-MM-DD"
       views: 0, // Inicializa as views como 0
       audioUrl: normalizedAudioUrl,

--- a/src/app/admin/editor/page.tsx
+++ b/src/app/admin/editor/page.tsx
@@ -315,7 +315,7 @@ export default function Editor() {
       formData.append("postId", postId);
       const normalizedContent = normalizeMarkdownContent(content);
 
-      formData.append("markdownContent", normalizedContent);
+      formData.append("contentMarkdown", normalizedContent);
       formData.append("tags", tags);
       formData.append("cape", cape);
       if (friendImage) {

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -35,17 +35,17 @@ export async function PATCH(
     return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
   }
 
-  let markdownContent: string | null = null;
+  let contentMarkdown: string | null = null;
 
   try {
-    const body = (await req.json()) as { markdownContent?: unknown };
-    if (typeof body?.markdownContent !== "string") {
+    const body = (await req.json()) as { contentMarkdown?: unknown };
+    if (typeof body?.contentMarkdown !== "string") {
       return NextResponse.json(
-        { error: "markdownContent is required and must be a string" },
+        { error: "contentMarkdown is required and must be a string" },
         { status: 400 }
       );
     }
-    markdownContent = normalizeMarkdownContent(body.markdownContent);
+    contentMarkdown = normalizeMarkdownContent(body.contentMarkdown);
   } catch (error) {
     return NextResponse.json(
       { error: "Invalid request body" },
@@ -53,9 +53,9 @@ export async function PATCH(
     );
   }
 
-  if (!markdownContent || markdownContent.trim() === "") {
+  if (!contentMarkdown || contentMarkdown.trim() === "") {
     return NextResponse.json(
-      { error: "markdownContent must not be empty" },
+      { error: "contentMarkdown must not be empty" },
       { status: 400 }
     );
   }
@@ -69,8 +69,7 @@ export async function PATCH(
       { postId },
       {
         $set: {
-          markdownContent,
-          contentMarkdown: markdownContent,
+          contentMarkdown,
           updatedAt: new Date(),
         },
       }
@@ -85,19 +84,19 @@ export async function PATCH(
 
     if (shouldUseMdxRenderer) {
       try {
-        htmlContent = await renderPostMdx(markdownContent);
+        htmlContent = await renderPostMdx(contentMarkdown);
       } catch (error) {
         console.error(`MDX renderer failed for post ${postId}:`, error);
-        htmlContent = await renderMarkdown(markdownContent);
+        htmlContent = await renderMarkdown(contentMarkdown);
       }
     } else {
-      htmlContent = await renderMarkdown(markdownContent);
+      htmlContent = await renderMarkdown(contentMarkdown);
     }
 
     await triggerSitemapRegeneration();
 
     return NextResponse.json({
-      markdownContent,
+      contentMarkdown,
       htmlContent,
       updatedAt: new Date().toISOString(),
     });

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -21,7 +21,6 @@ type PostDocument = {
   date: string | Date;
   title: string;
   subtitle?: string | null;
-  markdownContent?: string;
   contentMarkdown?: string;
   htmlContent?: string;
   content?: string;
@@ -53,7 +52,6 @@ async function fetchPostById(id: string) {
           date: 1,
           title: 1,
           subtitle: 1,
-          markdownContent: 1,
           contentMarkdown: 1,
           htmlContent: 1,
           content: 1,
@@ -103,16 +101,16 @@ function extractPlainText(value: string): string {
 }
 
 function extractDescription(post: PostDocument): string {
-  const markdownContent =
-    typeof post.markdownContent === "string"
-      ? post.markdownContent
-      : typeof post.contentMarkdown === "string"
-        ? post.contentMarkdown
+  const markdownCandidate =
+    typeof post.contentMarkdown === "string"
+      ? post.contentMarkdown
+      : typeof post.htmlContent === "string"
+        ? post.htmlContent
         : typeof post.content === "string"
           ? post.content
           : "";
 
-  const normalizedMarkdown = normalizeMarkdownContent(markdownContent);
+  const normalizedMarkdown = normalizeMarkdownContent(markdownCandidate);
 
   if (normalizedMarkdown) {
     const paragraphs = normalizedMarkdown.split(/\n\s*\n/);
@@ -301,7 +299,7 @@ export default async function PostPage({ params }: PostPageProps) {
     typeof post.subtitle === "string" ? post.subtitle.trim() : "";
   const subtitle = rawSubtitle.length > 0 ? rawSubtitle : undefined;
   const markdownSourceRaw =
-    post.markdownContent ?? post.contentMarkdown ?? post.htmlContent ?? post.content ?? "";
+    post.contentMarkdown ?? post.htmlContent ?? post.content ?? "";
   const markdownSource = normalizeMarkdownContent(markdownSourceRaw);
   const shouldUseMdxRenderer = process.env.FEATURE_MDX_RENDERER === "true";
 

--- a/src/app/posts/[id]/post-editing-client.tsx
+++ b/src/app/posts/[id]/post-editing-client.tsx
@@ -88,7 +88,7 @@ export default function PostEditingClient({
               const response = await fetch(`/api/posts/${postId}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ markdownContent: markdownValue }),
+                body: JSON.stringify({ contentMarkdown: markdownValue }),
               });
 
               if (!response.ok) {
@@ -100,12 +100,12 @@ export default function PostEditingClient({
 
               const payload = (await response.json()) as {
                 htmlContent?: string;
-                markdownContent?: string;
+                contentMarkdown?: string;
               };
 
-              if (typeof payload.markdownContent === "string") {
-                setMarkdownValue(payload.markdownContent);
-                setLastSavedMarkdown(payload.markdownContent);
+              if (typeof payload.contentMarkdown === "string") {
+                setMarkdownValue(payload.contentMarkdown);
+                setLastSavedMarkdown(payload.contentMarkdown);
               }
               if (typeof payload.htmlContent === "string") {
                 setHtmlContent(payload.htmlContent);


### PR DESCRIPTION
## Summary
- stop accepting or writing the deprecated `markdownContent` field in API handlers and editor flows
- rely on `contentMarkdown` for post rendering with `htmlContent` only as a legacy fallback
- update client editors to send and consume `contentMarkdown` exclusively

## Testing
- `npm run lint` *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e0f729288322893680d3ce2e317a)