### PR TITLE
Reuse home post fetcher for sitemap generation

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -8,6 +8,10 @@ export type PostRecord = {
   date: string; // ISO string
   views: number;
   tags: string[];
+  audioUrl: string | null;
+  cape: string | null;
+  friendImage: string | null;
+  updatedAt: string | null;
 };
 
 export type FetchPostsArgs = {
@@ -96,6 +100,10 @@ export async function getPosts({
     date: 1,
     views: 1,
     tags: 1,
+    audioUrl: 1,
+    cape: 1,
+    friendImage: 1,
+    updatedAt: 1,
   } as const;
 
   const [items, total] = await Promise.all([
@@ -122,6 +130,19 @@ export async function getPosts({
       : post.tags
       ? [String(post.tags)]
       : [],
+    audioUrl:
+      typeof (post as any).audioUrl === "string" && (post as any).audioUrl.trim() !== ""
+        ? String((post as any).audioUrl).trim()
+        : null,
+    cape:
+      typeof (post as any).cape === "string" && (post as any).cape.trim() !== ""
+        ? String((post as any).cape).trim()
+        : null,
+    friendImage:
+      typeof (post as any).friendImage === "string" && (post as any).friendImage.trim() !== ""
+        ? String((post as any).friendImage).trim()
+        : null,
+    updatedAt: normalizeDate((post as any).updatedAt),
   }));
 
   const hasNext = page * pageSize < total;


### PR DESCRIPTION
## Summary
- reuse the same posts query used by the home page when generating sitemaps to align filtering
- map fetched posts into sitemap-ready entries with thumbnails, audio URLs, and debug logging
- extend post fetching to return media and updated timestamps needed for sitemap metadata

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e3bb62308322bc85ccea25b797db)