### PR TITLE
Add admin analytics toggle and storage-backed flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
 
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Flag opcional para suspender a coleta de analytics (padrão: true)
+ANALYTICS_ENABLED=true
+
 4. Rodar o projeto
 npm run dev
 
@@ -74,6 +77,14 @@ Build para produção
 
 npm run build
 npm start
+
+-----------------------------------------
+Configuração de analytics
+-----------------------------------------
+
+- O flag `analyticsEnabled` tem fonte de verdade no MongoDB (coleção `settings`, chave `analyticsEnabled`).
+- O valor inicial cai para a env `ANALYTICS_ENABLED` (padrão `true`) se não existir registro na coleção.
+- Admins podem ligar/desligar em tempo real pela página `/admin/analytics`, que usa o endpoint protegido `/api/admin/analytics/toggle`.
 
 -----------------------------------------
 Licença

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -8,6 +8,7 @@
   - `/api/posts` (GET) — retorna posts com paginação, respeitando `hidden` para visitantes; admins podem pedir `includeHidden=true`.
   - `/api/search-posts` (GET) — busca posts públicos com limites de tamanho, paginação e rate limit.
   - `/staff/[...action]` (POST) — ações internas (ex.: `deletePost`) via whitelist; exige admin e valida entradas.
+  - `/api/admin/analytics/toggle` (GET/POST) — só admins; lê e atualiza o flag `analyticsEnabled` salvo na coleção `settings`.
 
 ## Avaliação de autenticação/autorização
 - **Aplicação de papéis**: o middleware deriva o papel da sessão Clerk e exige autenticação para qualquer API fora da lista pública. Rotas administrativas de página também chamam `resolveAdminStatus` no servidor, reforçando a checagem. Apenas admins acessam `/admin` e `/staff`.
@@ -21,6 +22,7 @@
   - `/api/search-posts` limita tamanho de `query`, aplica paginação/rate limit e usa regex escapada para evitar padrões pesados.
   - `/staff/[...action]` utiliza whitelist de ações e validação estrita do payload.
 - **Formulários e ações do admin**: ações de role (`setRole`, `removeRole`) dependem do `resolveAdminStatus`; não há CSRF tokens além da proteção implícita de Server Actions.
+- **Suspensão de analytics**: o flag `analyticsEnabled` fica no MongoDB e desliga imediatamente `/api/analytics/collect`, que passa a responder 403/204 sem persistir eventos.
 
 ## Exposição de informações sensíveis
 - **Logs de servidor**: logs das APIs foram reduzidos para evitar vazamento de dados de posts ou stack traces completos.

--- a/components/analytics/AnalyticsToggle.tsx
+++ b/components/analytics/AnalyticsToggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+export function AnalyticsToggle({ initialEnabled }: { initialEnabled: boolean }) {
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const updateToggle = async (nextEnabled: boolean) => {
+    const previous = enabled;
+    setEnabled(nextEnabled);
+    setIsSaving(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/admin/analytics/toggle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: nextEnabled }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to update: ${response.status}`);
+      }
+
+      const data = (await response.json()) as { enabled?: boolean };
+      setEnabled(Boolean(data.enabled));
+      setMessage(data.enabled ? "Coleta ligada" : "Coleta desligada");
+    } catch (err) {
+      console.error("Failed to toggle analytics", err);
+      setEnabled(previous);
+      setError("Não foi possível salvar a configuração agora.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-zinc-50">Coleta de analytics</p>
+          <p className="text-xs text-zinc-400">Liga ou desliga o rastreamento de eventos do site.</p>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="h-4 w-4 accent-emerald-500"
+            checked={enabled}
+            disabled={isSaving}
+            onChange={(event) => updateToggle(event.target.checked)}
+          />
+          <span className="text-zinc-200">{enabled ? "Ligado" : "Desligado"}</span>
+        </label>
+      </div>
+      <div className="text-xs text-zinc-400">
+        {isSaving && <span className="text-amber-300">Salvando...</span>}
+        {!isSaving && message && <span className="text-emerald-300">{message}</span>}
+        {!isSaving && error && <span className="text-red-400">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { getMongoDb } from "@lib/mongo";
 import { resolveAdminStatus } from "@lib/admin";
 import { getFromDate, parseRange, type RangeKey } from "./utils";
+import { getAnalyticsEnabled } from "@lib/analytics/config";
+import { AnalyticsToggle } from "@components/analytics/AnalyticsToggle";
 
 type DeviceBreakdown = { device: string; count: number }[];
 type TopPageRow = {
@@ -287,6 +289,8 @@ export default async function AdminAnalyticsPage({
   const range = parseRange(sp?.range);
   const from = getFromDate(range);
 
+  const analyticsEnabled = await getAnalyticsEnabled();
+
   const [summary, device, topPages, series] = await Promise.all([
     getSummary(from),
     getDeviceBreakdown(from),
@@ -330,6 +334,8 @@ export default async function AdminAnalyticsPage({
           ))}
         </div>
       </div>
+
+      <AnalyticsToggle initialEnabled={analyticsEnabled} />
 
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">

--- a/src/app/api/admin/analytics/toggle/route.ts
+++ b/src/app/api/admin/analytics/toggle/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { assertAdminAccess } from "@lib/admin";
+import { getAnalyticsEnabled, setAnalyticsEnabled } from "@lib/analytics/config";
+
+async function ensureAdmin(): Promise<NextResponse | null> {
+  try {
+    await assertAdminAccess();
+    return null;
+  } catch {
+    return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const forbidden = await ensureAdmin();
+  if (forbidden) {
+    return forbidden;
+  }
+
+  const enabled = await getAnalyticsEnabled();
+  return NextResponse.json({ enabled });
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const forbidden = await ensureAdmin();
+  if (forbidden) {
+    return forbidden;
+  }
+
+  let enabled: unknown = null;
+  try {
+    const body = await req.json();
+    enabled = body?.enabled;
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  if (typeof enabled !== "boolean") {
+    return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
+  }
+
+  try {
+    const updated = await setAnalyticsEnabled(enabled);
+    return NextResponse.json({ enabled: updated });
+  } catch (error) {
+    console.error("Failed to update analyticsEnabled", error);
+    return NextResponse.json({ error: "Failed to persist flag" }, { status: 500 });
+  }
+}
+
+export const runtime = "nodejs";

--- a/src/app/api/analytics/collect/route.ts
+++ b/src/app/api/analytics/collect/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { getMongoDb } from "@lib/mongo";
 import { resolveAdminStatus } from "@lib/admin";
-import { getAnalyticsServerConfig } from "@lib/analytics/config";
+import { getAnalyticsEnabled, getAnalyticsServerConfig } from "@lib/analytics/config";
 import {
   ANALYTICS_SESSION_COOKIE_NAME,
   anonymizeNetworkIdentifier,
@@ -382,6 +382,11 @@ async function parseEvents(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
+  const analyticsEnabled = await getAnalyticsEnabled();
+  if (!analyticsEnabled) {
+    return new NextResponse(null, { status: 403 });
+  }
+
   if (!isAllowedOrigin(req)) {
     return new NextResponse(null, { status: 204 });
   }

--- a/src/app/api/analytics/collect/route.ts
+++ b/src/app/api/analytics/collect/route.ts
@@ -382,7 +382,7 @@ async function parseEvents(
 }
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const analyticsEnabled = await getAnalyticsEnabled();
+  const analyticsEnabled = await getAnalyticsEnabled({ bypassCache: true });
   if (!analyticsEnabled) {
     return new NextResponse(null, { status: 403 });
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { auth } from "@clerk/nextjs/server";
 
 import AnalyticsProvider from "@components/analytics/AnalyticsProvider";
-import { getAnalyticsClientConfig } from "@lib/analytics/config";
+import { getAnalyticsClientConfig, getAnalyticsEnabled } from "@lib/analytics/config";
 import { resolveAdminStatus } from "@lib/admin";
 
 type RootLayoutProps = Readonly<{
@@ -16,6 +16,7 @@ type RootLayoutProps = Readonly<{
 
 export default async function RootLayout({ children }: RootLayoutProps) {
   const analyticsConfig = getAnalyticsClientConfig();
+  const analyticsEnabledPromise = getAnalyticsEnabled();
 
   let isAdmin = false;
   let authState: Awaited<ReturnType<typeof auth>> | null = null;
@@ -38,6 +39,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
     }
   }
 
+  const analyticsEnabled = await analyticsEnabledPromise;
   const isAuthenticated = Boolean(authState?.userId);
 
   return (
@@ -49,6 +51,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
               isAdmin={isAdmin}
               config={analyticsConfig}
               isAuthenticated={isAuthenticated}
+              analyticsEnabled={analyticsEnabled}
             >
               {children}
             </AnalyticsProvider>

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -133,8 +133,10 @@ function setCachedAnalyticsEnabled(value: boolean) {
   };
 }
 
-export async function getAnalyticsEnabled(): Promise<boolean> {
-  const cached = getCachedAnalyticsEnabled();
+export async function getAnalyticsEnabled({
+  bypassCache = false,
+}: { bypassCache?: boolean } = {}): Promise<boolean> {
+  const cached = bypassCache ? null : getCachedAnalyticsEnabled();
   if (cached !== null) {
     return cached;
   }

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -1,3 +1,5 @@
+import { getMongoDb } from "@lib/mongo";
+
 import { AnalyticsEventName, parseEnabledEvents } from "./events";
 
 const DEFAULT_ENDPOINT = "/api/analytics/collect";
@@ -8,6 +10,8 @@ const DEFAULT_RATE_LIMIT_WINDOW_SECONDS = 60;
 const DEFAULT_RATE_LIMIT_MAX_EVENTS = 120;
 const DEFAULT_MAX_EVENTS_PER_REQUEST = 25;
 const DEFAULT_MAX_EVENT_BYTES = 4096;
+const ANALYTICS_ENABLED_CACHE_TTL_MS = 60_000;
+const ANALYTICS_ENABLED_SETTING_KEY = "analyticsEnabled";
 
 function toNumber(
   value: string | null | undefined,
@@ -45,6 +49,22 @@ function parseOrigins(value: string | null | undefined): string[] {
     .filter((origin) => origin.length > 0);
 }
 
+function parseBooleanFlag(value: string | null | undefined, fallback: boolean) {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+}
+
 export type AnalyticsClientConfig = {
   endpoint: string;
   enabledEvents: AnalyticsEventName[];
@@ -64,6 +84,79 @@ export type AnalyticsServerConfig = {
   maxEventsPerRequest: number;
   maxEventBytes: number;
 };
+
+type AnalyticsEnabledSetting = {
+  _id: typeof ANALYTICS_ENABLED_SETTING_KEY;
+  value: boolean;
+  updatedAt?: Date;
+};
+
+const DEFAULT_ANALYTICS_ENABLED = parseBooleanFlag(
+  process.env.ANALYTICS_ENABLED,
+  true
+);
+
+let analyticsEnabledCache: { value: boolean; expiresAt: number } | null = null;
+
+function getCachedAnalyticsEnabled(): boolean | null {
+  if (analyticsEnabledCache && analyticsEnabledCache.expiresAt > Date.now()) {
+    return analyticsEnabledCache.value;
+  }
+  return null;
+}
+
+function setCachedAnalyticsEnabled(value: boolean) {
+  analyticsEnabledCache = {
+    value,
+    expiresAt: Date.now() + ANALYTICS_ENABLED_CACHE_TTL_MS,
+  };
+}
+
+export async function getAnalyticsEnabled(): Promise<boolean> {
+  const cached = getCachedAnalyticsEnabled();
+  if (cached !== null) {
+    return cached;
+  }
+
+  let storedValue: boolean | null = null;
+
+  try {
+    const db = await getMongoDb();
+    const storedSetting = await db
+      .collection<AnalyticsEnabledSetting>("settings")
+      .findOne({ _id: ANALYTICS_ENABLED_SETTING_KEY });
+
+    if (storedSetting && typeof storedSetting.value === "boolean") {
+      storedValue = storedSetting.value;
+    }
+  } catch (error) {
+    console.warn("Failed to fetch analyticsEnabled from storage", error);
+  }
+
+  const value =
+    storedValue ?? parseBooleanFlag(process.env.ANALYTICS_ENABLED, DEFAULT_ANALYTICS_ENABLED);
+  setCachedAnalyticsEnabled(value);
+  return value;
+}
+
+export async function setAnalyticsEnabled(enabled: boolean): Promise<boolean> {
+  try {
+    const db = await getMongoDb();
+    await db
+      .collection<AnalyticsEnabledSetting>("settings")
+      .updateOne(
+        { _id: ANALYTICS_ENABLED_SETTING_KEY },
+        { $set: { value: enabled, updatedAt: new Date() } },
+        { upsert: true }
+      );
+  } catch (error) {
+    console.error("Failed to persist analyticsEnabled flag", error);
+    throw error;
+  }
+
+  setCachedAnalyticsEnabled(enabled);
+  return enabled;
+}
 
 export function getAnalyticsClientConfig(): AnalyticsClientConfig {
   const enabledEvents = parseEnabledEvents(process.env.ANALYTICS_ENABLED_EVENTS);

--- a/tests/root-layout-admin.test.tsx
+++ b/tests/root-layout-admin.test.tsx
@@ -13,9 +13,10 @@ const adminStub = `
 `;
 
 const analyticsProviderStub = `
-  export default function AnalyticsProvider({ children, isAdmin, isAuthenticated }) {
+  export default function AnalyticsProvider({ children, isAdmin, isAuthenticated, analyticsEnabled }) {
     globalThis.__TEST_ANALYTICS_IS_ADMIN = isAdmin;
     globalThis.__TEST_ANALYTICS_IS_AUTHENTICATED = isAuthenticated;
+    globalThis.__TEST_ANALYTICS_ENABLED = analyticsEnabled;
     return children;
   }
 `;
@@ -32,6 +33,7 @@ const analyticsConfigStub = `
     maxBatchSize: 0,
     maxQueueSize: 0,
   });
+  export const getAnalyticsEnabled = async () => globalThis.__TEST_ANALYTICS_ENABLED_VALUE ?? true;
 `;
 
 const analyticsComponentStub = `
@@ -50,6 +52,8 @@ void test("RootLayout skips admin resolution for anonymous users", async () => {
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
     __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
+    __TEST_ANALYTICS_ENABLED?: boolean;
+    __TEST_ANALYTICS_ENABLED_VALUE?: boolean;
   }).__TEST_AUTH_STATE = { userId: null, sessionClaims: null };
 
   (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN = async () => {
@@ -77,16 +81,21 @@ void test("RootLayout skips admin resolution for anonymous users", async () => {
     (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED,
     false,
   );
+  assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED?: boolean }).__TEST_ANALYTICS_ENABLED, true);
 
   delete (globalThis as typeof globalThis & {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
     __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
+    __TEST_ANALYTICS_ENABLED?: boolean;
+    __TEST_ANALYTICS_ENABLED_VALUE?: boolean;
   }).__TEST_AUTH_STATE;
   delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED?: boolean }).__TEST_ANALYTICS_ENABLED;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED_VALUE?: boolean }).__TEST_ANALYTICS_ENABLED_VALUE;
 });
 
 void test("RootLayout forwards admin flag when user is signed in", async () => {
@@ -98,6 +107,8 @@ void test("RootLayout forwards admin flag when user is signed in", async () => {
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
     __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
+    __TEST_ANALYTICS_ENABLED?: boolean;
+    __TEST_ANALYTICS_ENABLED_VALUE?: boolean;
   }).__TEST_AUTH_STATE = {
     userId: "user_123",
     sessionClaims: { publicMetadata: { role: "admin" } },
@@ -133,14 +144,19 @@ void test("RootLayout forwards admin flag when user is signed in", async () => {
     (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED,
     true,
   );
+  assert.equal((globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED?: boolean }).__TEST_ANALYTICS_ENABLED, true);
 
   delete (globalThis as typeof globalThis & {
     __TEST_AUTH_STATE?: unknown;
     __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }>;
     __TEST_ANALYTICS_IS_ADMIN?: boolean;
     __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean;
+    __TEST_ANALYTICS_ENABLED?: boolean;
+    __TEST_ANALYTICS_ENABLED_VALUE?: boolean;
   }).__TEST_AUTH_STATE;
   delete (globalThis as typeof globalThis & { __TEST_RESOLVE_ADMIN?: (...args: unknown[]) => Promise<{ isAdmin: boolean; userId: string | null }> }).__TEST_RESOLVE_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_ADMIN?: boolean }).__TEST_ANALYTICS_IS_ADMIN;
   delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_IS_AUTHENTICATED?: boolean }).__TEST_ANALYTICS_IS_AUTHENTICATED;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED?: boolean }).__TEST_ANALYTICS_ENABLED;
+  delete (globalThis as typeof globalThis & { __TEST_ANALYTICS_ENABLED_VALUE?: boolean }).__TEST_ANALYTICS_ENABLED_VALUE;
 });


### PR DESCRIPTION
## Summary
- add persistent `analyticsEnabled` flag with Mongo-backed helper and env fallback
- expose admin-only API and UI toggle, wiring layout/provider to honor the flag
- short-circuit analytics collection when disabled and document configuration behavior

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693373db5cfc8322973bf6f6fed28b28)