### PR TITLE
Adjust admin sidebar structure and navigation

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,9 +5,10 @@ import { ReactNode, useState } from "react";
 import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
 
 const navItems = [
-  { href: "/admin", label: "Dashboard" },
-  { href: "/admin/users", label: "Usuários" },
-  { href: "/admin/editor", label: "Novo post" },
+  { href: "/admin", label: "dashboard" },
+  { href: "/admin/users", label: "users" },
+  { href: "/admin/editor", label: "new post" },
+  { href: "/admin/analytics", label: "Analytics" },
 ];
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
@@ -15,21 +16,20 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100 overflow-x-hidden">
-      <div className="grid min-h-screen grid-cols-1 md:grid-cols-[260px_1fr]">
+      <div className="grid min-h-screen grid-cols-1 md:grid-cols-[220px_1fr]">
         <aside className="hidden md:flex md:flex-col border-r border-zinc-800 bg-zinc-900/40">
-          <div className="p-5 border-b border-zinc-800">
-            <Link href="/admin" className="inline-flex items-center gap-2">
-              <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-zinc-100 text-zinc-900 font-bold">A</span>
-              <span className="text-lg font-semibold tracking-tight">Admin</span>
+          <div className="px-5 py-4 border-b border-zinc-800">
+            <Link href="/admin" className="text-base font-semibold tracking-tight">
+              domenyk.com
             </Link>
           </div>
-          <nav className="flex-1 p-3">
-            <ul className="space-y-1">
+          <nav className="flex-1 px-5 py-5">
+            <ul className="space-y-5">
               {navItems.map((item) => (
                 <li key={item.href}>
                   <Link
                     href={item.href}
-                    className="block rounded-md px-3 py-2 text-sm hover:bg-zinc-800/60"
+                    className="block text-sm tracking-wide text-zinc-200 hover:text-zinc-50"
                   >
                     {item.label}
                   </Link>
@@ -37,7 +37,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
               ))}
             </ul>
           </nav>
-          <div className="p-4 border-t border-zinc-800">
+          <div className="p-4 border-t border-zinc-800 mt-auto">
             <SignedIn>
               <div className="flex items-center justify-between rounded-md bg-zinc-900 px-4 py-3">
                 <span className="text-xs text-zinc-400">Logado</span>
@@ -54,7 +54,7 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
           </div>
         </aside>
         <div className="flex flex-col">
-          <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/70 backdrop-blur supports-[backdrop-filter]:bg-zinc-950/60">
+          <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/70 backdrop-blur supports-[backdrop-filter]:bg-zinc-950/60 md:hidden">
             <div className="flex items-center justify-between gap-4 px-6 py-4 md:px-8">
               <div className="flex items-center gap-3 md:hidden">
                 <button
@@ -81,12 +81,6 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
                   </svg>
                 </button>
                 <Link href="/admin" className="font-semibold">Admin</Link>
-              </div>
-              <div className="hidden md:block">
-                <Link href="/admin" className="inline-flex items-center gap-2">
-                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-zinc-100 text-zinc-900 font-bold">A</span>
-                  <span className="text-lg font-semibold tracking-tight">Admin</span>
-                </Link>
               </div>
               <div className="flex-1" />
               <div className="flex items-center gap-4">
@@ -131,5 +125,4 @@ export default function AdminLayout({ children }: { children: ReactNode }) {
     </div>
   );
 }
-
 


### PR DESCRIPTION
### Motivation
- Align the admin left sidebar with the provided ASCII layout: fixed left column with branding on top and vertical nav below.
- Make the desktop layout a clear two-column sidebar+content layout and keep the top header reserved for mobile.

### Description
- Updated navigation items and order to `dashboard`, `users`, `new post`, and added `Analytics` by modifying the `navItems` array in `src/app/admin/layout.tsx`.
- Changed sidebar branding from the previous compact logo to the text `domenyk.com` and reduced the sidebar width from `260px` to `220px` for a tighter column.
- Adjusted sidebar spacing and styles: increased vertical spacing between nav entries, switched nav link classes to `text-sm tracking-wide text-zinc-200 hover:text-zinc-50`, and moved the auth panel to the bottom with `mt-auto`.
- Made the top header visible only on mobile by adding `md:hidden` so desktop uses the left sidebar layout exclusively.

### Testing
- `npm run build` was attempted and failed in this environment due to missing runtime environment variables/services (`MONGODB_URI`, `MONGODB_DB`, and Clerk publishable key).
- Verified visually by running the app with local env overrides using `MONGODB_URI='mongodb://localhost:27017' MONGODB_DB='test' npm run dev -- --port 3000`, which compiled and served `/admin` successfully.
- Captured a Playwright screenshot of `http://localhost:3000/admin` to validate the updated sidebar layout (artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bc00c9c4832293264ecfb68b9103)