### PR TITLE
Adicionar separador e exibição de tags antes dos comentários do post

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -32,6 +32,7 @@ type PostDocument = {
   hidden?: boolean;
   paragraphCommentsEnabled?: boolean;
   updatedAt?: string | Date;
+  tags?: string[];
 };
 
 type PostPageProps = {
@@ -62,6 +63,7 @@ async function fetchPostById(id: string) {
           coAuthorUserId: 1,
           hidden: 1,
           paragraphCommentsEnabled: 1,
+          tags: 1,
         },
       }
     );
@@ -399,6 +401,7 @@ export default async function PostPage({ params }: PostPageProps) {
         paragraphCommentsEnabled={paragraphCommentsEnabled}
         isAdmin={isAdmin}
         initialMarkdown={markdownSource}
+        tags={Array.isArray(post.tags) ? post.tags : []}
       />
     </Layout>
   );

--- a/src/app/posts/[id]/post-editing-client.tsx
+++ b/src/app/posts/[id]/post-editing-client.tsx
@@ -21,6 +21,7 @@ export type PostEditingClientProps = {
   paragraphCommentsEnabled: boolean;
   isAdmin: boolean;
   initialMarkdown: string;
+  tags: string[];
 };
 
 export default function PostEditingClient({
@@ -36,6 +37,7 @@ export default function PostEditingClient({
   paragraphCommentsEnabled,
   isAdmin,
   initialMarkdown,
+  tags,
 }: PostEditingClientProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -191,6 +193,20 @@ export default function PostEditingClient({
           isEditing={false}
         />
       )}
+      <div className="mt-8 border-t border-zinc-200/80 pt-5 dark:border-zinc-700/80">
+        {tags.length > 0 && (
+          <div className="mb-5 flex flex-wrap items-center gap-2">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="inline-flex items-center rounded-full border border-zinc-300/80 px-3 py-1 text-xs font-medium text-zinc-700 dark:border-zinc-600 dark:text-zinc-200"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
       <BackHome />
       {isAdmin && (
         <div className="mt-4 sm:mt-6 mb-2">


### PR DESCRIPTION
### Motivation
- Separar visualmente o conteúdo do post e os comentários com uma linha divisória e exibir as `tags` do post logo abaixo dessa linha para melhorar a navegabilidade e contexto do artigo.

### Description
- Adiciona `tags?: string[]` ao tipo `PostDocument` e inclui `tags: 1` na projeção ao carregar o post em `src/app/posts/[id]/page.tsx` para disponibilizar as tags no servidor.
- Repassa `tags` para o cliente via prop `tags={Array.isArray(post.tags) ? post.tags : []}` em `PostEditingClient` na mesma rota de post.
- Atualiza `PostEditingClient` (`src/app/posts/[id]/post-editing-client.tsx`) adicionando a prop `tags: string[]` e renderizando uma seção com `border-t` que mostra as tags como chips (`#tag`) imediatamente acima do bloco de comentários.

### Testing
- Executado `npm run build`, que falhou devido a variáveis de ambiente do MongoDB não definidas no ambiente (`MONGODB_URI` e `MONGODB_DB`).
- Executado `npx tsc --noEmit`, que falhou por erros de tipagem preexistentes em `tests/` (ex.: tipos ausentes para `react-test-renderer`) não relacionados a esta alteração.
- Tentativa de captura com Playwright não foi possível porque o Chromium do container encerrou com `SIGSEGV` ao iniciar, impedindo o screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997c51952d48322b34924063ea15fdc)