### PR TITLE
Add minimalist footer to shared layout

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -19,6 +19,8 @@ type LayoutProps = {
 };
 
 export function Layout({ home = false, children, hideHeaderControls = false }: LayoutProps) {
+  const currentYear = new Date().getFullYear();
+
   return (
     <div
       data-scroll-progress-root
@@ -41,6 +43,13 @@ export function Layout({ home = false, children, hideHeaderControls = false }: L
       <main className={`${home ? "home" : ""} flex flex-col flex-1`}>
         {children}
       </main>
+      <footer
+        className="mt-10 mb-4 text-center text-sm leading-relaxed text-zinc-400"
+        style={{ fontFamily: "Calibri, Candara, Segoe, 'Segoe UI', Optima, Arial, sans-serif" }}
+      >
+        <p>© {currentYear} domenyk.com</p>
+        <p className="mt-1 break-all">bc1qfv788krszr8xz3uxvvzy33pp8jph0hw53557d4</p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Add a simple, centered and minimal footer across the site that shows the current year and the provided BTC address while keeping a low-contrast, well-spaced style that works on desktop and mobile.

### Description
- Inserted a footer in `components/layout.tsx` that computes the year with `new Date().getFullYear()`, displays `© {currentYear} domenyk.com` and the BTC address `bc1qfv788krszr8xz3uxvvzy33pp8jph0hw53557d4`, applies muted text/spacing and a Calibri-first font stack, and ensures long-address wrapping with `break-all`.

### Testing
- Ran `npm run build`, which failed in this environment due to missing `MONGODB_URI`/`MONGODB_DB` required for page-data collection; attempted `MONGODB_URI='mongodb://localhost:27017' MONGODB_DB='test' npm run dev`, which started but requests failed with MongoDB connection refused errors; and attempted automated Playwright screenshots, which timed out, so no successful visual artifacts were produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ccd4fc3c8322abe73b7c518f2d0c)