### PR TITLE
Add admin post download (ZIP) endpoint and client UI; add jszip dependency; refactor post page props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "dotenv": "^17.2.3",
         "gray-matter": "^4.0.3",
         "html-react-parser": "^5.2.8",
+        "jszip": "^3.10.1",
         "lexical": "^0.38.2",
         "minidenticons": "^4.2.1",
         "mongodb": "^7.0.0",
@@ -50,6 +51,7 @@
         "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
+        "@types/jszip": "^3.4.0",
         "@types/node": "^24.10.0",
         "@types/react": "19.2.2",
         "@types/react-dom": "19.2.2",
@@ -2122,6 +2124,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2565,6 +2577,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3616,6 +3634,18 @@
         "entities": "^6.0.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.6.tgz",
@@ -3687,6 +3717,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
@@ -3738,6 +3774,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3773,6 +3821,15 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -5377,6 +5434,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -5464,6 +5527,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5547,6 +5616,21 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/recma-build-jsx": {
@@ -5848,6 +5932,12 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5884,6 +5974,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
     "node_modules/sharp": {
@@ -5978,6 +6074,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -6382,6 +6487,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^17.2.3",
     "gray-matter": "^4.0.3",
     "html-react-parser": "^5.2.8",
+    "jszip": "^3.10.1",
     "lexical": "^0.38.2",
     "minidenticons": "^4.2.1",
     "mongodb": "^7.0.0",
@@ -50,6 +51,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@types/jszip": "^3.4.0",
     "@types/node": "^24.10.0",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -312,6 +312,32 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
     }
   }
 
+  const handleDownload = async () => {
+    const ids = selectedIds.length > 0 ? selectedIds : "all";
+    try {
+      const res = await fetch("/admin/api/posts/download", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ postIds: ids }),
+      });
+      if (!res.ok) {
+        const err = (await res.json()) as { error?: string };
+        alert(err.error || "Erro ao baixar posts.");
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `posts-${Date.now()}.zip`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.error(e);
+      alert("Erro ao baixar posts.");
+    }
+  };
+
   const headerCells = [
     { key: "select", label: "", className: "md:w-12" },
     { key: "title", label: "Título" },
@@ -334,36 +360,41 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
   return (
     <>
       <div className="space-y-4">
-        {selectedIds.length > 0 && (
-          <div className="rounded-lg border border-zinc-700/80 bg-zinc-800/50 p-3 shadow-sm">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="text-sm text-zinc-300">{selectedIds.length} selecionado(s)</div>
-              <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
-                <button
-                  onClick={() => bulkAction("visibility", { hidden: false })}
-                  disabled={bulkLoading}
-                  className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60 sm:w-auto"
-                >
-                  Tornar visível
-                </button>
-                <button
-                  onClick={() => bulkAction("visibility", { hidden: true })}
-                  disabled={bulkLoading}
-                  className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
-                >
-                  Ocultar
-                </button>
-                <button
-                  onClick={() => bulkAction("delete")}
-                  disabled={bulkLoading}
-                  className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-red-300 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
-                >
-                  Excluir
-                </button>
-              </div>
+        <div className="rounded-lg border border-zinc-700/80 bg-zinc-800/50 p-3 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-zinc-300">{selectedIds.length} selecionado(s)</div>
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+              <button
+                onClick={handleDownload}
+                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
+                title={selectedIds.length > 0 ? `Baixar ${selectedIds.length} post(s) selecionado(s)` : "Baixar todos os posts"}
+              >
+                {selectedIds.length > 0 ? `⬇ Baixar (${selectedIds.length})` : "⬇ Baixar todos"}
+              </button>
+              <button
+                onClick={() => bulkAction("visibility", { hidden: false })}
+                disabled={bulkLoading || selectedIds.length === 0}
+                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60 sm:w-auto"
+              >
+                Tornar visível
+              </button>
+              <button
+                onClick={() => bulkAction("visibility", { hidden: true })}
+                disabled={bulkLoading || selectedIds.length === 0}
+                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
+              >
+                Ocultar
+              </button>
+              <button
+                onClick={() => bulkAction("delete")}
+                disabled={bulkLoading || selectedIds.length === 0}
+                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-red-300 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
+              >
+                Excluir
+              </button>
             </div>
           </div>
-        )}
+        </div>
 
         <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 p-3">
           <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-300">

--- a/src/app/admin/api/posts/download/route.ts
+++ b/src/app/admin/api/posts/download/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import JSZip from "jszip";
+import { clientPromise } from "../../../../../lib/mongo";
+import { resolveAdminStatus } from "../../../../../lib/admin";
+
+export async function POST(request: NextRequest) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { postIds } = body as { postIds: string[] | "all" };
+
+  const client = await clientPromise;
+  const db = client.db(process.env.MONGODB_DB || "blog");
+  const collection = db.collection("posts");
+
+  let posts;
+  if (postIds === "all") {
+    posts = await collection
+      .find({}, { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, content: 1, date: 1, tags: 1 } })
+      .toArray();
+  } else {
+    if (!Array.isArray(postIds) || postIds.length === 0) {
+      return NextResponse.json({ error: "Nenhum post selecionado." }, { status: 400 });
+    }
+    posts = await collection
+      .find(
+        { postId: { $in: postIds } },
+        { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, content: 1, date: 1, tags: 1 } }
+      )
+      .toArray();
+  }
+
+  if (!posts || posts.length === 0) {
+    return NextResponse.json({ error: "Nenhum post encontrado." }, { status: 404 });
+  }
+
+  const zip = new JSZip();
+  const folder = zip.folder("posts")!;
+
+  for (const post of posts) {
+    const safeTitle = (post.title || post.postId || "post")
+      .replace(/[^a-zA-Z0-9À-ÿ\s\-_]/g, "")
+      .trim()
+      .replace(/\s+/g, "_")
+      .substring(0, 80);
+
+    const lines: string[] = [];
+    lines.push(`# ${post.title || ""}`);
+    if (post.subtitle) lines.push(`## ${post.subtitle}`);
+    lines.push("");
+    if (post.date) lines.push(`Data: ${post.date}`);
+    if (post.tags?.length) lines.push(`Tags: ${post.tags.join(", ")}`);
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+    lines.push(post.contentMarkdown || post.content || "");
+
+    folder.file(`${safeTitle}.txt`, lines.join("\n"));
+  }
+
+  const zipBuffer = await zip.generateAsync({ type: "arraybuffer" });
+
+  return new NextResponse(zipBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="posts-${Date.now()}.zip"`,
+    },
+  });
+}

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -265,13 +265,9 @@ export default async function PostPage({ params }: PostPageProps) {
   const normalizedContent = normalizeMarkdownContent(rawContent);
 
   let renderedHtml = "";
-  let isMdx = false;
-
   if (!isStaticGenerationEnvironment()) {
     try {
-      const mdxResult = await renderPostMdx(normalizedContent, post.postId);
-      renderedHtml = mdxResult.html;
-      isMdx = true;
+      renderedHtml = await renderPostMdx(normalizedContent);
     } catch {
       renderedHtml = await renderMarkdown(normalizedContent);
     }
@@ -284,25 +280,26 @@ export default async function PostPage({ params }: PostPageProps) {
 
   return (
     <Layout>
+      <PostHeader
+        cape={post.cape}
+        title={post.title}
+        subtitle={post.subtitle ?? undefined}
+        friendImage={post.friendImage}
+      />
       <PostEditingClient
-        post={{
-          postId: post.postId,
-          title: post.title,
-          subtitle: post.subtitle ?? null,
-          date,
-          views: post.views ?? 0,
-          audioUrl: post.audioUrl ?? null,
-          cape: post.cape ?? null,
-          friendImage: post.friendImage ?? null,
-          coAuthorUserId: post.coAuthorUserId ?? null,
-          hidden: post.hidden ?? false,
-          paragraphCommentsEnabled: post.paragraphCommentsEnabled ?? false,
-          tags: post.tags ?? [],
-        }}
-        renderedHtml={renderedHtml}
-        isMdx={isMdx}
+        postId={post.postId}
+        title={post.title}
+        date={date}
+        initialHtmlContent={renderedHtml}
+        initialViews={post.views ?? 0}
+        audioUrl={post.audioUrl}
         readingTime={readingTime}
+        coAuthorUserId={post.coAuthorUserId ?? null}
+        coAuthorImageUrl={post.friendImage ?? null}
+        paragraphCommentsEnabled={post.paragraphCommentsEnabled ?? false}
         isAdmin={isAdmin}
+        initialMarkdown={normalizedContent}
+        tags={post.tags ?? []}
       />
     </Layout>
   );


### PR DESCRIPTION
### Motivation

- Provide an admin feature to download selected or all posts as a ZIP archive for backup/export. 
- Add the `jszip` dependency and its types to support ZIP generation on the server. 
- Simplify and align props passed to the post editing client and add a `PostHeader` to the post view for clearer layout.

### Description

- Added `jszip` and `@types/jszip` to `package.json` and updated `package-lock.json` to include the new dependency and its transitive packages. 
- Implemented a new API route at `src/app/admin/api/posts/download/route.ts` that verifies admin status, fetches posts from MongoDB (selected or all), generates a ZIP with a `posts/` folder, and returns it with `Content-Type: application/zip`. 
- Extended the admin posts client (`src/app/admin/RecentPostsClient.tsx`) with a `handleDownload` function and a download button that posts selected post IDs (or `"all"`) to the new endpoint, triggers a file download, and shows appropriate messages on error. 
- Always render the admin bulk-action bar (previously conditional) and disable visibility/delete actions when no selection is present; added titles and improved button states. 
- Updated the public post page (`src/app/posts/[id]/page.tsx`) to use `renderPostMdx(normalizedContent)` without the old return shape, add a `PostHeader` component, and refactor the props passed to `PostEditingClient` to individual fields (`postId`, `title`, `date`, `initialHtmlContent`, `initialViews`, `audioUrl`, `readingTime`, `coAuthorUserId`, `coAuthorImageUrl`, `paragraphCommentsEnabled`, `initialMarkdown`, `tags`, and `isAdmin`). 

### Testing

- No automated tests were added or run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a823791f248322803772d143be6c85)