### PR TITLE
Include htmlContent in posts export and use as fallback in download route

### DIFF
--- a/src/app/admin/api/posts/download/route.ts
+++ b/src/app/admin/api/posts/download/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: NextRequest) {
   let posts;
   if (postIds === "all") {
     posts = await collection
-      .find({}, { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, content: 1, date: 1, tags: 1 } })
+      .find({}, { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, htmlContent: 1, content: 1, date: 1, tags: 1 } })
       .toArray();
   } else {
     if (!Array.isArray(postIds) || postIds.length === 0) {
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
     posts = await collection
       .find(
         { postId: { $in: postIds } },
-        { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, content: 1, date: 1, tags: 1 } }
+        { projection: { postId: 1, title: 1, subtitle: 1, contentMarkdown: 1, htmlContent: 1, content: 1, date: 1, tags: 1 } }
       )
       .toArray();
   }
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
     lines.push("");
     lines.push("---");
     lines.push("");
-    lines.push(post.contentMarkdown || post.content || "");
+    lines.push(post.contentMarkdown || post.content || post.htmlContent || "");
 
     folder.file(`${safeTitle}.txt`, lines.join("\n"));
   }


### PR DESCRIPTION
### Motivation

- Ensure exported post archives include the `htmlContent` field so posts that only have rendered HTML are exported correctly.

### Description

- Added `htmlContent` to the MongoDB projection for both the `all` and filtered `postIds` queries in `route.ts` so the field is retrieved from the database.
- Updated the exported content assembly to use `contentMarkdown` first, then `content`, and finally `htmlContent` as a fallback when composing the post file.

### Testing

- Ran the project test suite with `npm test` and the tests passed.
- Executed the API export integration test that posts a set of `postIds` and verifies the generated ZIP contains post files with content populated from `htmlContent` when other fields are absent, and the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8432adc5083228bebb4fda75757ae)