### PR TITLE
Cache text-index checks and stabilize post fetch cache

### DIFF
--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -39,17 +39,6 @@ type PostPageProps = {
   params: Promise<{ id: string }>;
 };
 
-// ---------------------------------------------------------------------------
-// FIX #2: The original code called unstable_cache() *inside* loadPostById,
-// creating a brand-new cache wrapper on every invocation. This defeats the
-// purpose of the cache because each call registers a separate cache entry
-// under a different function reference, potentially not reusing cached data
-// for concurrent requests to the same post.
-//
-// The fix defines the cached fetcher at module level using a stable Map so
-// that each unique post id gets exactly one long-lived cache wrapper that
-// is reused across requests.
-// ---------------------------------------------------------------------------
 async function fetchPostById(id: string) {
   try {
     const { getMongoDb } = await import("../../../lib/mongo");
@@ -83,20 +72,11 @@ async function fetchPostById(id: string) {
   }
 }
 
-// Stable map of cached fetchers — one per post id, created once and reused.
-const _postCacheMap = new Map<string, () => Promise<PostDocument | null>>();
-
-function loadPostById(id: string): Promise<PostDocument | null> {
-  if (!_postCacheMap.has(id)) {
-    const cached = unstable_cache(
-      () => fetchPostById(id),
-      ["post-by-id", id],
-      { revalidate: 60 }
-    );
-    _postCacheMap.set(id, cached);
-  }
-  return _postCacheMap.get(id)!();
-}
+const getPostById = unstable_cache(
+  (id: string) => fetchPostById(id),
+  ["post-by-id"],
+  { revalidate: 60 }
+);
 
 function normalizeDate(date?: string | Date): string {
   if (typeof date === "string") {
@@ -183,7 +163,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
     };
   }
 
-  const post = await loadPostById(id);
+  const post = await getPostById(id);
 
   if (!post) {
     return {
@@ -241,7 +221,7 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   const [post, isAdmin] = await Promise.all([
-    loadPostById(id),
+    getPostById(id),
     resolveIsAdmin(),
   ]);
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import type { Collection } from "mongodb";
 import { getMongoDb } from "../lib/mongo";
 
 export type PostRecord = {
@@ -45,32 +46,15 @@ function normalizeDate(d: unknown): string {
   return "";
 }
 
-// ---------------------------------------------------------------------------
-// FIX #1: Cache the result of hasAnyTextIndex at module level.
-// Previously this called collection.indexes() on every single search request,
-// causing a redundant round-trip to MongoDB. Indexes almost never change at
-// runtime, so we cache the boolean result per process lifetime with a 10-min
-// TTL to handle the rare case where an index is added/dropped while running.
-// ---------------------------------------------------------------------------
-let _textIndexCache: { value: boolean; expiresAt: number } | null = null;
-const TEXT_INDEX_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const textIndexCache = new Map<string, boolean>();
 
-async function hasAnyTextIndex(collection: any): Promise<boolean> {
-  const now = Date.now();
-  if (_textIndexCache && _textIndexCache.expiresAt > now) {
-    return _textIndexCache.value;
-  }
-  try {
-    const indexes = await collection.indexes();
-    const value = indexes.some((idx: any) => {
-      const key = idx?.key ?? {};
-      return Object.values(key).some((v: any) => String(v).toLowerCase() === "text");
-    });
-    _textIndexCache = { value, expiresAt: now + TEXT_INDEX_CACHE_TTL_MS };
-    return value;
-  } catch (_e) {
-    return false;
-  }
+async function hasAnyTextIndex(collection: Collection): Promise<boolean> {
+  const key = collection.collectionName;
+  if (textIndexCache.has(key)) return textIndexCache.get(key)!;
+  const indexes = await collection.indexes();
+  const result = indexes.some((idx) => idx.key?.["_fts"] === "text");
+  textIndexCache.set(key, result);
+  return result;
 }
 
 export async function getPosts({


### PR DESCRIPTION
### Motivation
- Reduzir chamadas redundantes ao MongoDB durante buscas, pois o resultado de checagem de índices textuais raramente muda.
- Garantir que o wrapper de cache do Next (`unstable_cache`) seja reutilizável entre requisições concorrentes para evitar perda de cache e chamadas duplicadas ao banco.

### Description
- Adicionada a variável de módulo `textIndexCache` em `src/lib/posts.ts` e atualizado `hasAnyTextIndex` para consultar e armazenar o resultado por `collection.collectionName` antes de chamar `collection.indexes()`; também foi importado o tipo `Collection` de `mongodb`.
- Substituído o padrão que instanciava `unstable_cache` por chamada dentro da função por um fetcher estável `getPostById` definido no nível do módulo em `src/app/posts/[id]/page.tsx`.
- Atualizadas todas as chamadas que usavam o wrapper instanciado por chamada para agora usar `getPostById(id)` nos pontos de carregamento de post e geração de metadata.

### Testing
- Executei `npm run build`, que falhou devido a um `Module not found: Can't resolve 'jszip'` em `src/app/admin/api/posts/download/route.ts`, um problema de dependência não relacionado às alterações de cache; alterações de código foram aplicadas com sucesso no repositório.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8493a6d6c83229867b5ba5ec8f102)