### PR TITLE
Add paragraph comments summary endpoint and client-side comment count indicators

### DIFF
--- a/components/paragraph-comments/CommentIndicator.tsx
+++ b/components/paragraph-comments/CommentIndicator.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
+
+type Props = {
+  count: number;
+  onClick: () => void;
+};
+
+const CommentIndicator = React.memo(function CommentIndicator({
+  count,
+  onClick,
+}: Props) {
+  if (count === 0) return null;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${count} comentário${count > 1 ? "s" : ""} neste parágrafo`}
+      className="inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-xs font-medium text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"
+    >
+      <ChatBubbleLeftRightIcon className="h-3 w-3" />
+      {count}
+    </button>
+  );
+});
+
+export default CommentIndicator;

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -13,6 +13,7 @@ import { sanitizeCommentHtml } from "@components/comments/utils";
 import { UPPERCASE_MAX_RATIO, getUppercaseState, buildUppercaseErrorMessage } from "@components/comments/uppercaseUtils";
 import type { ParagraphComment } from "../../types/paragraph-comments";
 import { useAnalytics } from "@components/analytics/AnalyticsProvider";
+import CommentIndicator from "./CommentIndicator";
 
 const LOGIN_PROMPT_TIMEOUT_MS = 5000;
 
@@ -48,6 +49,7 @@ type ParagraphCommentWidgetProps = {
   children: React.ReactNode;
   isAdmin: boolean;
   isMobile: boolean;
+  initialCount?: number;
 };
 
 export default function ParagraphCommentWidget({
@@ -59,6 +61,7 @@ export default function ParagraphCommentWidget({
   children,
   isAdmin,
   isMobile,
+  initialCount = 0,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -88,6 +91,8 @@ export default function ParagraphCommentWidget({
   const undoTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const undoIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [isUndoingDelete, setIsUndoingDelete] = useState(false);
+  const [localDelta, setLocalDelta] = useState(0);
+  const displayCount = hasLoaded ? comments.length : initialCount + localDelta;
   const { trackEvent, isTrackingEnabled } = useAnalytics();
 
   const clearPendingDeleteTimeout = useCallback(() => {
@@ -452,6 +457,7 @@ export default function ParagraphCommentWidget({
 
       const data = (await response.json()) as { comment: ParagraphComment };
       setComments((prev) => [...prev, data.comment]);
+      if (!hasLoaded) setLocalDelta((d) => d + 1);
       setDraft("");
       setErrorMessage(null);
       setIsFeatureBlocked(false);
@@ -545,6 +551,7 @@ export default function ParagraphCommentWidget({
         }
 
         setComments((prev) => prev.filter((comment) => comment._id !== commentId));
+        if (!hasLoaded) setLocalDelta((d) => d - 1);
         setIsFeatureBlocked(false);
         showUndoToast(commentToDelete);
       } catch (error) {
@@ -717,6 +724,14 @@ export default function ParagraphCommentWidget({
         >
           <ChatBubbleLeftRightIcon className="h-4 w-4" />
         </button>
+        {!isExpanded && displayCount > 0 && (
+          <span className="absolute right-[-2rem] top-1/2 -translate-y-1/2">
+            <CommentIndicator
+              count={displayCount}
+              onClick={toggleComments}
+            />
+          </span>
+        )}
       </div>
 
       {isExpanded && (
@@ -919,5 +934,4 @@ export default function ParagraphCommentWidget({
     </>
   );
 }
-
 

--- a/components/paragraph-comments/useCommentsSummary.ts
+++ b/components/paragraph-comments/useCommentsSummary.ts
@@ -1,0 +1,26 @@
+import useSWR from "swr";
+
+type SummaryItem = { paragraphId: string; count: number };
+
+const fetcher = (url: string) =>
+  fetch(url).then((res) => {
+    if (!res.ok) throw new Error("summary fetch failed");
+    return res.json() as Promise<SummaryItem[]>;
+  });
+
+export function useCommentsSummary(postId: string) {
+  const { data } = useSWR<SummaryItem[]>(
+    `/api/posts/${postId}/paragraph-comments/summary`,
+    fetcher,
+    { dedupingInterval: 30_000, revalidateOnFocus: false }
+  );
+
+  const summaryMap = new Map<string, number>();
+  if (data) {
+    for (const item of data) {
+      summaryMap.set(item.paragraphId, item.count);
+    }
+  }
+
+  return summaryMap;
+}

--- a/src/app/api/posts/[id]/paragraph-comments/summary/route.ts
+++ b/src/app/api/posts/[id]/paragraph-comments/summary/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+
+import { getMongoDb } from "../../../../../../lib/mongo";
+
+const COLLECTION_NAME = "paragraph-comments";
+
+type SummaryItem = {
+  paragraphId: string;
+  count: number;
+};
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const resolvedParams = await params;
+  const postId = resolvedParams?.id;
+
+  if (!postId) {
+    return NextResponse.json({ error: "Post ID inválido." }, { status: 400 });
+  }
+
+  try {
+    const db = await getMongoDb();
+    const postsCollection = db.collection("posts");
+    const post = await postsCollection.findOne(
+      { postId },
+      { projection: { _id: 1, paragraphCommentsEnabled: 1 } }
+    );
+
+    if (!post) {
+      return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+    }
+
+    if ((post as any).paragraphCommentsEnabled === false) {
+      return NextResponse.json(
+        { error: "Comentários por parágrafo desativados para este post." },
+        { status: 403 }
+      );
+    }
+
+    const collection = db.collection(COLLECTION_NAME);
+
+    const summary = (await collection
+      .aggregate([
+        { $match: { postId } },
+        { $group: { _id: "$paragraphId", count: { $sum: 1 } } },
+        { $project: { _id: 0, paragraphId: "$_id", count: 1 } },
+      ])
+      .toArray()) as SummaryItem[];
+
+    return NextResponse.json(summary, { status: 200 });
+  } catch (error) {
+    console.error("Failed to fetch paragraph comments summary", error);
+    return NextResponse.json(
+      { error: "Erro interno ao buscar resumo de comentários." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import parse, {
   DOMNode,
   Element,
@@ -12,14 +14,17 @@ import PostContentShell, {
   type ParagraphCommentWidgetProps,
 } from "./post-content-interactive";
 import type { HTMLAttributes, RefObject } from "react";
+import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 
 function renderParagraphWithComments(
   node: Element,
   parserOptions: HTMLReactParserOptions,
   paragraphIndex: number,
   options: Pick<ParagraphCommentWidgetProps, "postId" | "coAuthorUserId" | "isAdmin">,
+  summaryMap: Map<string, number>,
 ) {
   const paragraphId = `${options.postId}-paragraph-${paragraphIndex}`;
+  const initialCount = summaryMap.get(paragraphId) ?? 0;
   const paragraphProps = attributesToProps(node.attribs ?? {}) as HTMLAttributes<HTMLParagraphElement>;
   const enhancedParagraphProps: HTMLAttributes<HTMLParagraphElement> = {
     ...paragraphProps,
@@ -41,6 +46,7 @@ function renderParagraphWithComments(
       paragraphProps={enhancedParagraphProps}
       isAdmin={options.isAdmin}
       isMobile={false}
+      initialCount={initialCount}
     >
       {domToReact((node.children ?? []) as DOMNode[], parserOptions)}
     </LazyParagraphCommentWidget>
@@ -92,6 +98,7 @@ export default function PostContentClient({
   isEditing = false,
   contentRef,
 }: PostContentClientProps) {
+  const summaryMap = useCommentsSummary(postId);
   let paragraphIndex = 0;
 
   type ReplaceReturn = ReturnType<NonNullable<HTMLReactParserOptions["replace"]>>;
@@ -128,7 +135,7 @@ export default function PostContentClient({
         postId,
         coAuthorUserId,
         isAdmin,
-      });
+      }, summaryMap);
     }
 
     if (node.type === "tag" && node.name === "p" && !paragraphCommentsEnabled) {

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -32,6 +32,7 @@ export type ParagraphCommentWidgetProps = {
   children: ReactNode;
   isAdmin: boolean;
   isMobile: boolean;
+  initialCount?: number;
 };
 
 export type ParagraphCommentWidgetComponent = ComponentType<ParagraphCommentWidgetProps>;


### PR DESCRIPTION
### Motivation

- Surface per-paragraph comment counts in the article UI using a lightweight summary API to avoid loading full comment threads eagerly. 
- Provide a compact indicator button for paragraphs with comments so readers can see and open discussion threads. 
- Keep client behavior consistent when the full comment thread hasn't been loaded by showing an initial server-provided count and adjusting for local adds/deletes.

### Description

- Added a server API route `GET /api/posts/[id]/paragraph-comments/summary` that aggregates comment counts per paragraph from the `paragraph-comments` MongoDB collection and returns a list of `{ paragraphId, count }` items. 
- Implemented a `useCommentsSummary` hook that fetches the summary via SWR with a 30s deduping interval and exposes a `Map<paragraphId, count>`. 
- Plumbed an `initialCount` prop through `post-content-client` -> `post-content-interactive` -> `ParagraphCommentWidget` to provide an initial count for each paragraph. 
- Added a `CommentIndicator` UI component and integrated it into `ParagraphCommentWidget` to render a compact count button when the comments panel is collapsed. 
- Implemented local optimistic delta tracking (`localDelta`) so `ParagraphCommentWidget` displays `initialCount + localDelta` before the thread is loaded and updates `localDelta` on submit/delete operations.

### Testing

- No new automated tests were added for this change. 
- Existing automated checks (type checking and the repository CI/test suite) were run and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84aa65df0832298164c96ce04aee9)