### PR TITLE
Corrige abertura de comentários no mobile após lazy-load do widget

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -50,6 +50,7 @@ type ParagraphCommentWidgetProps = {
   isAdmin: boolean;
   isMobile: boolean;
   initialCount?: number;
+  autoOpen?: boolean;
 };
 
 export default function ParagraphCommentWidget({
@@ -62,6 +63,7 @@ export default function ParagraphCommentWidget({
   isAdmin,
   isMobile,
   initialCount = 0,
+  autoOpen = false,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -660,6 +662,11 @@ export default function ParagraphCommentWidget({
       }
     };
   }, [closeLoginPrompt, loginPromptCycle, showLoginPrompt, userId]);
+
+  useEffect(() => {
+    if (!autoOpen) return;
+    void openComments();
+  }, [autoOpen, openComments]);
 
   useEffect(() => {
     const onOtherParagraphOpen = (e: Event) => {

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -33,6 +33,7 @@ export type ParagraphCommentWidgetProps = {
   isAdmin: boolean;
   isMobile: boolean;
   initialCount?: number;
+  autoOpen?: boolean;
 };
 
 export type ParagraphCommentWidgetComponent = ComponentType<ParagraphCommentWidgetProps>;
@@ -128,13 +129,15 @@ ParagraphContent.displayName = "ParagraphContent";
 
 export function LazyParagraphCommentWidget(props: ParagraphCommentWidgetProps) {
   const [shouldRenderWidget, setShouldRenderWidget] = useState(false);
+  const [pendingOpen, setPendingOpen] = useState(false);
   const [Widget, setWidget] = useState<ParagraphCommentWidgetComponent | null>(null);
   const placeholderRef = useRef<HTMLParagraphElement | null>(null);
   const contextIsMobile = useContext(IsMobileContext);
   const { isMobile: propIsMobile, ...restProps } = props;
   const isMobile = (contextIsMobile ?? propIsMobile) ?? false;
 
-  const ensureWidget = useCallback(() => {
+  const ensureWidget = useCallback((withOpen = false) => {
+    if (withOpen) setPendingOpen(true);
     setShouldRenderWidget((previous) => (previous ? previous : true));
   }, []);
 
@@ -196,7 +199,7 @@ export function LazyParagraphCommentWidget(props: ParagraphCommentWidgetProps) {
       <ParagraphContent
         ref={placeholderRef}
         paragraphProps={props.paragraphProps}
-        onLoadRequest={ensureWidget}
+        onLoadRequest={() => ensureWidget(isMobile)}
       >
         {props.children}
       </ParagraphContent>
@@ -215,7 +218,7 @@ export function LazyParagraphCommentWidget(props: ParagraphCommentWidgetProps) {
     );
   }
 
-  return <Widget {...restProps} isMobile={isMobile} />;
+  return <Widget {...restProps} isMobile={isMobile} autoOpen={pendingOpen} />;
 }
 
 const IsMobileContext = createContext<boolean | null>(null);


### PR DESCRIPTION
### Motivation
- No mobile um toque no parágrafo deveria abrir o painel de comentários, mas o `LazyParagraphCommentWidget` carregado dinamicamente perdia o gesto porque o widget montava com `isExpanded: false` sem saber do clique pendente.

### Description
- Adicionei `autoOpen?: boolean` ao tipo `ParagraphCommentWidgetProps` e ao componente para transmitir intenção de abertura ao widget carregado.
- No `LazyParagraphCommentWidget` criei o estado `pendingOpen`, alterei `ensureWidget` para `ensureWidget(withOpen = false)` que marca `pendingOpen` quando apropriado, e passei `autoOpen={pendingOpen}` ao componente carregado dinamicamente.
- Altere o placeholder para `onLoadRequest={() => ensureWidget(isMobile)}` para que um toque em mobile solicite abertura imediata durante o lazy-load.
- No `ParagraphCommentWidget` desestruturei `autoOpen = false` e adicionei um `useEffect` que chama `openComments()` quando `autoOpen` for true, garantindo abertura (sem alternar) após o carregamento.

### Testing
- Rodei `npx tsc --noEmit`, que falhou por erros de tipagem pré-existentes em `tests/post-reference.test.tsx` e não relacionados às alterações feitas; as mudanças locais não introduziram erros de compilação nos arquivos modificados.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a852a6314c83229d233387024ca05f)