### PR TITLE
Add per-section attention tracking and admin scroll heatmap

### DIFF
--- a/components/analytics/SectionAttentionTracker.tsx
+++ b/components/analytics/SectionAttentionTracker.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAnalytics } from "./AnalyticsProvider";
+
+const SECTIONS = 10;
+const TICK_MS = 1000;
+const CAP_SECONDS = 120;
+
+export default function SectionAttentionTracker({ postId }: { postId: string }) {
+  const { trackEvent } = useAnalytics();
+  const secondsRef = useRef<number[]>(new Array(SECTIONS).fill(0));
+  const flushedRef = useRef<number[]>(new Array(SECTIONS).fill(0));
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    secondsRef.current = new Array(SECTIONS).fill(0);
+    flushedRef.current = new Array(SECTIONS).fill(0);
+
+    const getCurrentSection = (): number | null => {
+      const content = document.querySelector<HTMLElement>("[data-post-content]");
+      if (!content) return null;
+
+      const rect = content.getBoundingClientRect();
+      const contentH = content.offsetHeight;
+      if (contentH === 0) return null;
+
+      const centerInContent = -rect.top + window.innerHeight / 2;
+      if (centerInContent < 0 || centerInContent > contentH) return null;
+
+      const section = Math.min(SECTIONS - 1, Math.floor((centerInContent / contentH) * SECTIONS));
+      return section;
+    };
+
+    tickRef.current = setInterval(() => {
+      if (document.visibilityState !== "visible") return;
+      const section = getCurrentSection();
+      if (section === null) return;
+      if (secondsRef.current[section] < CAP_SECONDS) {
+        secondsRef.current[section] += 1;
+      }
+    }, TICK_MS);
+
+    const flush = () => {
+      secondsRef.current.forEach((total, i) => {
+        const delta = total - flushedRef.current[i];
+        if (delta > 0) {
+          trackEvent("section_attention", {
+            postId,
+            section: i,
+            seconds: delta,
+          });
+          flushedRef.current[i] = total;
+        }
+      });
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", flush);
+
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", flush);
+      flush();
+    };
+  }, [postId, trackEvent]);
+
+  return null;
+}

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import VisibilityToggle from "./VisibilityToggle";
 import ParagraphCommentsToggle from "./ParagraphCommentsToggle";
 import CommentsModal from "./CommentsModal";
+import ScrollHeatmap from "./ScrollHeatmap";
 
 type PostRow = {
   postId: string;
@@ -516,6 +517,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
                 <div className={`${cellBase} md:text-right`}>
                   <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Views</div>
                   <div className="text-sm">{p.views ?? 0}</div>
+                  <ScrollHeatmap postId={p.postId} />
                 </div>
                 <div className={`${cellBase} md:text-right`}>
                   <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Comentários</div>

--- a/src/app/admin/ScrollHeatmap.tsx
+++ b/src/app/admin/ScrollHeatmap.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type HeatmapRow = { section: number; totalSeconds: number };
+
+const SECTIONS = 10;
+
+function fmt(s: number): string {
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m${s % 60 > 0 ? `${s % 60}s` : ""}`;
+}
+
+export default function ScrollHeatmap({ postId }: { postId: string }) {
+  const [data, setData] = useState<HeatmapRow[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/admin/api/scroll-heatmap?postId=${encodeURIComponent(postId)}`)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [postId]);
+
+  if (loading) {
+    return <div className="text-xs text-zinc-500">Carregando heatmap...</div>;
+  }
+
+  if (!data || data.length === 0) {
+    return <div className="text-xs text-zinc-500">Sem dados de atenção ainda.</div>;
+  }
+
+  const map = new Map(data.map((d) => [d.section, d.totalSeconds]));
+  const max = Math.max(...Array.from(map.values()), 1);
+
+  const width = 600;
+  const height = 80;
+  const padX = 24;
+  const padY = 12;
+  const innerW = width - padX * 2;
+  const innerH = height - padY * 2;
+
+  const pts = Array.from({ length: SECTIONS }, (_, i) => {
+    const x = padX + (i / (SECTIONS - 1)) * innerW;
+    const y = padY + innerH - ((map.get(i) ?? 0) / max) * innerH;
+    return { x, y, i };
+  });
+
+  const polyline = pts.map((p) => `${p.x},${p.y}`).join(" ");
+  const area = [`${padX},${padY + innerH}`, ...pts.map((p) => `${p.x},${p.y}`), `${padX + innerW},${padY + innerH}`].join(" ");
+
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium text-zinc-400">Atenção por seção do post</div>
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="w-full h-auto">
+        <polyline fill="rgba(250,204,21,0.12)" stroke="none" points={area} />
+        <polyline fill="none" stroke="#facc15" strokeWidth={2} strokeLinejoin="round" points={polyline} />
+        {pts.map(({ x, y, i }) => {
+          const s = map.get(i) ?? 0;
+          return (
+            <g key={i}>
+              <circle cx={x} cy={y} r={3} fill="#facc15" />
+              {s > 0 && (
+                <text x={x} y={y - 5} textAnchor="middle" fontSize={8} fill="#a1a1aa">
+                  {fmt(s)}
+                </text>
+              )}
+              <text x={x} y={height - 1} textAnchor="middle" fontSize={9} fill="#52525b">
+                {i * 10}%
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <div className="flex justify-between text-[10px] text-zinc-600 px-1">
+        <span>início</span>
+        <span>fim</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/api/scroll-heatmap/route.ts
+++ b/src/app/admin/api/scroll-heatmap/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { resolveAdminStatus } from "@lib/admin";
+import { getMongoDb } from "@lib/mongo";
+
+export async function GET(req: Request) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const postId = url.searchParams.get("postId");
+  if (!postId) {
+    return NextResponse.json({ error: "postId required" }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  const events = db.collection("analytics_events");
+
+  const rows = await events
+    .aggregate<{ section: number; totalSeconds: number }>([
+      {
+        $match: {
+          name: "section_attention",
+          "data.postId": postId,
+        },
+      },
+      {
+        $group: {
+          _id: { session: "$session", section: "$data.section" },
+          sessionSeconds: { $sum: "$data.seconds" },
+        },
+      },
+      {
+        $project: {
+          section: "$_id.section",
+          sessionSeconds: {
+            $min: ["$sessionSeconds", 120],
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$section",
+          totalSeconds: { $sum: "$sessionSeconds" },
+        },
+      },
+      {
+        $project: { _id: 0, section: "$_id", totalSeconds: 1 },
+      },
+      { $sort: { section: 1 } },
+    ])
+    .toArray();
+
+  return NextResponse.json(rows, { status: 200 });
+}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -13,6 +13,7 @@ import PostContentShell, {
   LazyParagraphCommentWidget,
   type ParagraphCommentWidgetProps,
 } from "./post-content-interactive";
+import SectionAttentionTracker from "@components/analytics/SectionAttentionTracker";
 import type { HTMLAttributes, RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 
@@ -158,6 +159,7 @@ export default function PostContentClient({
       isEditing={isEditing}
       contentRef={contentRef}
     >
+      <SectionAttentionTracker postId={postId} />
       {parsedContent}
     </PostContentShell>
   );

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -4,6 +4,7 @@ export const ANALYTICS_EVENT_NAMES = [
   "comment_submit",
   "search_query",
   "sort_change",
+  "section_attention",
 ] as const;
 
 export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number];
@@ -11,6 +12,7 @@ export type AnalyticsEventName = (typeof ANALYTICS_EVENT_NAMES)[number];
 const DEFAULT_EVENTS: AnalyticsEventName[] = [
   "page_view",
   "comment_submit",
+  "section_attention",
 ];
 
 export function parseEnabledEvents(value: string | null | undefined): AnalyticsEventName[] {


### PR DESCRIPTION
### Motivation

- Capture how long readers spend on different vertical sections of a post to measure attention distribution. 
- Expose aggregated attention data to admins in the admin UI to surface which parts of a post attract the most attention. 
- Ensure the analytics system recognizes the new event type so it can be enabled/disabled like other events.

### Description

- Add a client-side tracker `SectionAttentionTracker` that ticks every second while the page is visible, attributes a reader to one of `SECTIONS` sections based on the content center, caps per-section tracking at `CAP_SECONDS`, and flushes deltas via `trackEvent("section_attention", { postId, section, seconds })` on visibility changes and pagehide. 
- Add an admin UI component `ScrollHeatmap` that fetches `/admin/api/scroll-heatmap?postId=...` and renders a small SVG area/line chart and formatted per-section seconds. 
- Add a new API route `src/app/admin/api/scroll-heatmap/route.ts` that requires admin access and aggregates `analytics_events` for `section_attention`, grouping by session+section, capping session seconds at 120, and returning total seconds per section. 
- Integrate the tracker into post rendering by mounting `SectionAttentionTracker` in `post-content-client.tsx` and surface the heatmap in the admin `RecentPostsClient` list by rendering `ScrollHeatmap` next to the views column. 
- Register the new event name by adding `"section_attention"` to `ANALYTICS_EVENT_NAMES` and include it in `DEFAULT_EVENTS` in `src/lib/analytics/events.ts`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a862fd9330832289a8bae10391c85a)