### PR TITLE
Adicionar overlay público de heatmap de atenção por seção na barra de progresso

### DIFF
--- a/components/HeatmapProgressBar.tsx
+++ b/components/HeatmapProgressBar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Bucket = { section: number; totalSeconds: number };
+
+function buildGradient(buckets: Bucket[]): string {
+  const max = Math.max(...buckets.map((b) => b.totalSeconds), 1);
+  const stops = buckets.map((b, i) => {
+    const opacity = 0.15 + (b.totalSeconds / max) * 0.75;
+    const from = `${i * 10}%`;
+    const to = `${(i + 1) * 10}%`;
+    return `rgba(224, 0, 112, ${opacity.toFixed(3)}) ${from},
+            rgba(224, 0, 112, ${opacity.toFixed(3)}) ${to}`;
+  });
+
+  return `linear-gradient(to right, ${stops.join(", ")})`;
+}
+
+export default function HeatmapProgressBar({ postId }: { postId: string }) {
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/posts/${encodeURIComponent(postId)}/attention-heatmap`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (!data.available) return;
+
+        const gradient = buildGradient(data.buckets);
+        document.documentElement.style.setProperty("--scroll-heatmap-gradient", gradient);
+        document.documentElement.style.setProperty("--scroll-heatmap-visible", "1");
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      document.documentElement.style.setProperty("--scroll-heatmap-visible", "0");
+    };
+  }, [postId]);
+
+  return null;
+}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -28,6 +28,7 @@ export function Layout({ home = false, children, hideHeaderControls = false }: L
     >
       <ScrollProgressEffect />
       <header className="flex justify-between items-center py-1">
+        <div aria-hidden="true" data-scroll-heatmap-bar />
         <div aria-hidden="true" data-scroll-progress-bar />
         {hideHeaderControls ? (
           <span aria-hidden className="h-8 w-8" />

--- a/src/app/api/posts/[id]/attention-heatmap/route.ts
+++ b/src/app/api/posts/[id]/attention-heatmap/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { getMongoDb } from "@lib/mongo";
+
+const MIN_SESSIONS = 10;
+const SECTIONS = 10;
+const CAP_SECONDS = 120;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: postId } = await params;
+  if (!postId) {
+    return NextResponse.json({ error: "postId required" }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  const events = db.collection("analytics_events");
+
+  const sessionCount = await events.distinct("session", {
+    name: "section_attention",
+    "data.postId": postId,
+  });
+
+  if (sessionCount.length < MIN_SESSIONS) {
+    return NextResponse.json({ available: false }, { status: 200 });
+  }
+
+  const rows = await events
+    .aggregate<{ section: number; totalSeconds: number }>([
+      { $match: { name: "section_attention", "data.postId": postId } },
+      {
+        $group: {
+          _id: { session: "$session", section: "$data.section" },
+          sessionSeconds: { $sum: "$data.seconds" },
+        },
+      },
+      {
+        $project: {
+          section: "$_id.section",
+          sessionSeconds: { $min: ["$sessionSeconds", CAP_SECONDS] },
+        },
+      },
+      {
+        $group: {
+          _id: "$section",
+          totalSeconds: { $sum: "$sessionSeconds" },
+        },
+      },
+      { $project: { _id: 0, section: "$_id", totalSeconds: 1 } },
+      { $sort: { section: 1 } },
+    ])
+    .toArray();
+
+  const map = new Map(rows.map((r) => [r.section, r.totalSeconds]));
+  const buckets = Array.from({ length: SECTIONS }, (_, i) => ({
+    section: i,
+    totalSeconds: map.get(i) ?? 0,
+  }));
+
+  return NextResponse.json({ available: true, buckets }, { status: 200 });
+}

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -112,10 +112,22 @@ h1 {
   transition: width 0.12s ease-out, opacity 0.12s ease-out;
 }
 
+[data-scroll-heatmap-bar] {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0px));
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: var(--scroll-heatmap-gradient, transparent);
+  pointer-events: none;
+  z-index: 9998;
+  opacity: var(--scroll-heatmap-visible, 0);
+  transition: opacity 0.3s ease-out;
+}
+
 @media (prefers-reduced-motion: reduce) {
   [data-scroll-progress-bar] {
     transition: none;
   }
 }
-
 

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -14,6 +14,7 @@ import PostContentShell, {
   type ParagraphCommentWidgetProps,
 } from "./post-content-interactive";
 import SectionAttentionTracker from "@components/analytics/SectionAttentionTracker";
+import HeatmapProgressBar from "@components/HeatmapProgressBar";
 import type { HTMLAttributes, RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 
@@ -160,6 +161,7 @@ export default function PostContentClient({
       contentRef={contentRef}
     >
       <SectionAttentionTracker postId={postId} />
+      <HeatmapProgressBar postId={postId} />
       {parsedContent}
     </PostContentShell>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,6 +26,7 @@ const isPublicApiRoute = createRouteMatcher([
   "/api/analytics/collect",
   "/api/posts",
   "/api/posts/shorten-url",
+  "/api/posts/(.*)/attention-heatmap",
   "/api/posts/(.*)",
   "/api/search-posts",
   "/api/comments(.*)",


### PR DESCRIPTION
### Motivation
- Mostrar, para todos os leitores, um overlay de heatmap sobre a barra de progresso que revela quais seções do post recebem mais atenção ao longo do tempo.
- Agregar dados de atenção por seção de forma pública e segura no servidor, com limiar mínimo de sessões e cap por sessão para evitar vieses.

### Description
- Adiciona o componente cliente `components/HeatmapProgressBar.tsx` que busca `/api/posts/[id]/attention-heatmap`, constrói um gradiente e expõe o resultado via propriedades CSS (`--scroll-heatmap-gradient`, `--scroll-heatmap-visible`).
- Cria a rota pública `src/app/api/posts/[id]/attention-heatmap/route.ts` que agrega eventos `section_attention` em 10 buckets, aplica cap de 120s por sessão e só retorna dados quando há pelo menos 10 sessões distintas.
- Insere o elemento visual `<div data-scroll-heatmap-bar />` em `components/layout.tsx` imediatamente antes da barra de progresso existente e adiciona estilos em `src/app/global.css` para posicionar o overlay com `z-index: 9998` e altura `3px`.
- Registra a rota como pública adicionando `"/api/posts/(.*)/attention-heatmap"` ao matcher em `src/middleware.ts` e integra `HeatmapProgressBar` em `src/app/posts/[id]/post-content-client.tsx` ao lado do `SectionAttentionTracker`; `section_attention` já existia em `src/lib/analytics/events.ts`.

### Testing
- Executado `npm run build`, que falhou por falta de variáveis/serviços de runtime (erro: MONGODB_* e Clerk), não relacionado ao patch.
- Executado `npx tsc --noEmit`, que falhou devido a erros de tipagem pré-existentes em testes (`tests/post-reference.test.tsx`), não introduzidos por este PR.
- Iniciado o servidor em modo dev com `MONGODB_URI='mongodb://localhost:27017' MONGODB_DB='test' npm run dev`, que levantou a aplicação mas registrou falhas de conexão com Mongo e ausência de chave Clerk (ambiente incompleto), portanto não houve validação end-to-end do heatmap.
- Tentativas automatizadas de captura via Playwright falharam por timeouts/indisponibilidade do navegador no ambiente; nenhuma falha de runtime do código adicionado foi observada nos artefatos locais durante os testes automatizados acima.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86a9500108322b8a857047b7a51b9)