### PR TITLE
Add post pinning feature (admin toggle, API, sorting, and UI display)

### DIFF
--- a/src/app/admin/PinToggle.tsx
+++ b/src/app/admin/PinToggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+export default function PinToggle({
+  postId,
+  pinnedOrder,
+}: {
+  postId: string;
+  pinnedOrder?: number | null;
+}) {
+  const [pinned, setPinned] = useState(pinnedOrder != null);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = () => {
+    startTransition(async () => {
+      setError(null);
+      try {
+        const res = await fetch("/admin/api/pin", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ postId, pin: !pinned }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        setPinned((p) => !p);
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2 justify-end">
+      <button
+        onClick={toggle}
+        disabled={isPending}
+        className={`px-2 py-1 rounded text-xs border transition-colors ${
+          pinned
+            ? "bg-zinc-100 text-zinc-900 border-zinc-200"
+            : "bg-zinc-800 text-zinc-200 border-zinc-700"
+        } disabled:opacity-60`}
+        title={pinned ? "Desafixar post" : "Fixar post na home"}
+      >
+        {pinned ? "Fixado" : "Fixar"}
+      </button>
+      {error && <span className="text-red-500 text-xs">{error}</span>}
+    </div>
+  );
+}

--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import VisibilityToggle from "./VisibilityToggle";
+import PinToggle from "./PinToggle";
 import ParagraphCommentsToggle from "./ParagraphCommentsToggle";
 import CommentsModal from "./CommentsModal";
 import ScrollHeatmap from "./ScrollHeatmap";
@@ -19,6 +20,7 @@ type PostRow = {
   categories?: string[];
   coAuthorUserId?: string | null;
   paragraphCommentsEnabled?: boolean;
+  pinnedOrder?: number | null;
 };
 
 type SortKey = "date" | "views" | "status";
@@ -351,6 +353,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
     { key: "categories", label: "Categorias" },
     { key: "coAuthor", label: "Co-autor" },
     { key: "paragraphs", label: "Parágrafos", align: "right" as const },
+    { key: "pinned", label: "Fixado", align: "right" as const },
     { key: "visibility", label: "Visibilidade", align: "right" as const },
   ];
 
@@ -592,6 +595,14 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
                         )
                       }
                     />
+                  </div>
+                </div>
+                <div className={`${cellBase} md:text-right`}>
+                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">
+                    Fixado
+                  </div>
+                  <div className="mt-2 md:mt-0">
+                    <PinToggle postId={p.postId} pinnedOrder={p.pinnedOrder} />
                   </div>
                 </div>
                 <div className={`${cellBase} md:text-right`}>

--- a/src/app/admin/api/pin/route.ts
+++ b/src/app/admin/api/pin/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { resolveAdminStatus } from "@lib/admin";
+import { getMongoDb } from "@lib/mongo";
+
+export async function POST(req: Request) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Not Authorized" }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const postId =
+    typeof (body as any)?.postId === "string" ? (body as any).postId : null;
+  const pin = (body as any)?.pin;
+
+  if (!postId || typeof pin !== "boolean") {
+    return NextResponse.json(
+      { error: "postId and pin (boolean) are required" },
+      { status: 400 }
+    );
+  }
+
+  const db = await getMongoDb();
+  const posts = db.collection("posts");
+
+  if (pin) {
+    await posts.updateMany(
+      { postId: { $ne: postId } },
+      { $unset: { pinnedOrder: "" } }
+    );
+
+    const result = await posts.updateOne(
+      { postId },
+      { $set: { pinnedOrder: 0 } }
+    );
+
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+  } else {
+    const result = await posts.updateOne(
+      { postId },
+      { $unset: { pinnedOrder: "" } }
+    );
+
+    if (result.matchedCount === 0) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+  }
+
+  return NextResponse.json({ postId, pinned: pin }, { status: 200 });
+}

--- a/src/app/admin/api/posts/route.ts
+++ b/src/app/admin/api/posts/route.ts
@@ -47,6 +47,7 @@ export async function GET(req: Request) {
       categories: 1,
       coAuthorUserId: 1,
       paragraphCommentsEnabled: 1,
+      pinnedOrder: 1,
     } as const;
 
     // Build sort doc

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -15,6 +15,7 @@ export type PostData = {
   date: string;
   views: number;
   tags: string[];
+  pinnedOrder?: number | null;
 };
 
 type HomeClientProps = {
@@ -192,7 +193,28 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
       ) : (
         <ul className="text-xl ml-0 flex flex-col gap-4">
           {posts.map((post) => (
-            <li key={post.postId} className="flex flex-col mb-2 group relative">
+            <li
+              key={post.postId}
+              className={`flex flex-col mb-2 group relative${
+                post.pinnedOrder != null
+                  ? " border-l-2 border-zinc-400 pl-3"
+                  : ""
+              }`}
+            >
+              {post.pinnedOrder != null && (
+                <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-zinc-400">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="size-3"
+                    aria-hidden="true"
+                  >
+                    <path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/>
+                  </svg>
+                  Fixado
+                </span>
+              )}
               <Link
                 href={`/posts/${post.postId}`}
                 prefetch={false}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -13,6 +13,7 @@ export type PostRecord = {
   cape: string | null;
   friendImage: string | null;
   updatedAt: string | null;
+  pinnedOrder: number | null;
 };
 
 export type FetchPostsArgs = {
@@ -104,14 +105,25 @@ export async function getPosts({
     cape: 1,
     friendImage: 1,
     updatedAt: 1,
+    pinnedOrder: 1,
   } as const;
 
   const [items, total] = await Promise.all([
     collection
-      .find(filter, { projection })
-      .sort({ [sortField]: sortOrder })
-      .skip(skip)
-      .limit(pageSize)
+      .aggregate([
+        { $match: filter },
+        {
+          $addFields: {
+            _pinnedSort: {
+              $ifNull: ["$pinnedOrder", 999999],
+            },
+          },
+        },
+        { $sort: { _pinnedSort: 1, [sortField]: sortOrder } },
+        { $skip: skip },
+        { $limit: pageSize },
+        { $project: { ...projection, _pinnedSort: 0 } },
+      ])
       .toArray(),
     collection.countDocuments(filter),
   ]);
@@ -143,6 +155,10 @@ export async function getPosts({
         ? String((post as any).friendImage).trim()
         : null,
     updatedAt: normalizeDate((post as any).updatedAt),
+    pinnedOrder:
+      typeof (post as any).pinnedOrder === "number"
+        ? (post as any).pinnedOrder
+        : null,
   }));
 
   const hasNext = page * pageSize < total;

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -122,7 +122,8 @@ export async function getPosts({
         { $sort: { _pinnedSort: 1, [sortField]: sortOrder } },
         { $skip: skip },
         { $limit: pageSize },
-        { $project: { ...projection, _pinnedSort: 0 } },
+        { $project: projection },
+        { $unset: "_pinnedSort" },
       ])
       .toArray(),
     collection.countDocuments(filter),


### PR DESCRIPTION
### Motivation
- Enable a single post to be pinned to the home view and managed from the admin UI so admins can highlight important content.
- Persist pinned state in the database and ensure pinned posts are prioritized in listing results.
- Provide a small admin UX for toggling pin state and show pinned posts to visitors.

### Description
- Added a new client component `PinToggle` (`src/app/admin/PinToggle.tsx`) that POSTs to `/admin/api/pin` and updates local state with optimistic UI and error handling. 
- Implemented the `/admin/api/pin` route (`src/app/admin/api/pin/route.ts`) with admin authorization and Mongo updates that set `pinnedOrder` for the selected post and unset it for others, or unset it when unpinning.
- Surface `pinnedOrder` across the stack by adding the field to projections and types in the posts API (`src/app/admin/api/posts/route.ts`) and the posts library (`src/lib/posts.ts`).
- Changed `getPosts` to use an aggregation that adds a `_pinnedSort` field and sorts pinned posts first before applying the configured sort and pagination, and map `pinnedOrder` into returned records.
- Updated admin recent posts list (`src/app/admin/RecentPostsClient.tsx`) to show a "Fixado" column and render the `PinToggle` control per row.
- Updated home client (`src/app/home-client.tsx`) to visually mark pinned posts with a border and label in the public list.

### Testing
- No automated tests were added or run as part of this change. 
- Recommend adding unit/integration tests for the `/admin/api/pin` route and for the `getPosts` aggregation behavior in future work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8ac6f79448322b0492c4a124a7afe)