### PR TITLE
Remover borda esquerda de posts fixados na lista inicial

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -195,11 +195,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
           {posts.map((post) => (
             <li
               key={post.postId}
-              className={`flex flex-col mb-2 group relative${
-                post.pinnedOrder != null
-                  ? " border-l-2 border-zinc-400 pl-3"
-                  : ""
-              }`}
+              className="flex flex-col mb-2 group relative"
             >
               {post.pinnedOrder != null && (
                 <span className="mb-1 inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-zinc-400">
@@ -279,7 +275,6 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
     </section>
   );
 }
-
 
 
 


### PR DESCRIPTION
### Motivation
- Remover a borda esquerda aplicada condicionalmente a posts fixados porque não combina com o visual existente e o indicador "Fixado" com ícone já é suficiente.

### Description
- Substituído o `className` condicional no item da lista em `src/app/home-client.tsx` por `className="flex flex-col mb-2 group relative"`, removendo a inserção de `border-l-2 border-zinc-400 pl-3` quando `post.pinnedOrder` estava presente.

### Testing
- Nenhum teste automatizado foi executado; a alteração é apenas de classes CSS/JSX e foi verificada por inspeção do arquivo atualizado (`src/app/home-client.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8b2a593748322a6b69cde0360cdcb)