### PR TITLE
Add ImageParagraph component with lightbox and paragraph-comments integration

### DIFF
--- a/components/ImageParagraph.tsx
+++ b/components/ImageParagraph.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { XMarkIcon } from "@heroicons/react/24/solid";
+
+type ImageParagraphProps = {
+  src: string;
+  alt: string;
+  isMobile: boolean;
+  paragraphCommentSlot?: React.ReactNode;
+  initialCommentCount?: number;
+};
+
+export default function ImageParagraph({
+  src,
+  alt,
+  isMobile,
+  paragraphCommentSlot,
+  initialCommentCount = 0,
+}: ImageParagraphProps) {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [commentsOpen, setCommentsOpen] = useState(false);
+  const lightboxRef = useRef<HTMLDivElement>(null);
+
+  const openLightbox = useCallback(() => setLightboxOpen(true), []);
+  const closeLightbox = useCallback(() => setLightboxOpen(false), []);
+  const toggleComments = useCallback(() => setCommentsOpen((v) => !v), []);
+
+  useEffect(() => {
+    if (!lightboxOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeLightbox();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [lightboxOpen, closeLightbox]);
+
+  useEffect(() => {
+    document.body.style.overflow = lightboxOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [lightboxOpen]);
+
+  return (
+    <>
+      <span className="relative block group my-2">
+        <img
+          src={src}
+          alt={alt}
+          onClick={isMobile ? toggleComments : openLightbox}
+          className={`
+            rounded-md w-full h-full cursor-zoom-in
+            transition-all duration-300
+            ${commentsOpen ? "grayscale-0" : "grayscale-100"}
+          `}
+        />
+
+        {isMobile && initialCommentCount > 0 && !commentsOpen && (
+          <span className="absolute bottom-2 right-2 flex items-center gap-1 rounded-full bg-black/60 px-2 py-0.5 text-[11px] text-white backdrop-blur-sm">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-3" aria-hidden>
+              <path fillRule="evenodd" d="M1 8.74C1 10.55 2.46 12 4.26 12H5v1.52a.75.75 0 0 0 1.14.642L9.11 12h2.63A3.25 3.25 0 0 0 15 8.74v-2.5A3.25 3.25 0 0 0 11.74 3H4.26A3.25 3.25 0 0 0 1 6.24v2.5Z" clipRule="evenodd" />
+            </svg>
+            {initialCommentCount}
+          </span>
+        )}
+
+        {!isMobile && (
+          <span className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-full bg-black/60 p-1.5 backdrop-blur-sm pointer-events-none">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-3 text-white" aria-hidden>
+              <path d="M6 1a5 5 0 1 1 0 10A5 5 0 0 1 6 1Zm.75 4.25v-1.5a.75.75 0 0 0-1.5 0v1.5h-1.5a.75.75 0 0 0 0 1.5h1.5v1.5a.75.75 0 0 0 1.5 0v-1.5h1.5a.75.75 0 0 0 0-1.5h-1.5ZM13.78 13.78a.75.75 0 0 1-1.06 0L10.22 11.28A6 6 0 1 1 11.28 10.22l2.5 2.5a.75.75 0 0 1 0 1.06Z" />
+            </svg>
+          </span>
+        )}
+      </span>
+
+      {isMobile && commentsOpen && (
+        <div className="rounded-2xl overflow-hidden border border-zinc-200 dark:border-zinc-800 shadow-lg mb-2">
+          <div className="relative bg-zinc-950">
+            <img
+              src={src}
+              alt={alt}
+              className="w-full h-auto max-h-64 object-contain grayscale-0"
+            />
+            <button
+              type="button"
+              onClick={toggleComments}
+              aria-label="Fechar"
+              className="absolute top-2 right-2 flex items-center justify-center rounded-full bg-black/60 p-1.5 backdrop-blur-sm"
+            >
+              <XMarkIcon className="h-4 w-4 text-white" />
+            </button>
+          </div>
+
+          <div className="p-3">{paragraphCommentSlot}</div>
+        </div>
+      )}
+
+      {lightboxOpen && (
+        <div
+          ref={lightboxRef}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/90 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === lightboxRef.current) closeLightbox();
+          }}
+        >
+          <button
+            type="button"
+            onClick={closeLightbox}
+            aria-label="Fechar"
+            className="absolute top-4 right-4 flex items-center justify-center rounded-full bg-white/10 p-2 transition-colors hover:bg-white/20"
+          >
+            <XMarkIcon className="h-5 w-5 text-white" />
+          </button>
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain grayscale-0 shadow-2xl"
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -10,13 +10,15 @@ import parse, {
 import PostReference from "@components/PostReference";
 import AutorReference from "@components/AutorReference";
 import PostContentShell, {
+  IsMobileContext,
   LazyParagraphCommentWidget,
   type ParagraphCommentWidgetProps,
 } from "./post-content-interactive";
 import SectionAttentionTracker from "@components/analytics/SectionAttentionTracker";
 import HeatmapProgressBar from "@components/HeatmapProgressBar";
-import type { HTMLAttributes, RefObject } from "react";
+import { useContext, type HTMLAttributes, type RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
+import ImageParagraph from "@components/ImageParagraph";
 
 function renderParagraphWithComments(
   node: Element,
@@ -71,7 +73,66 @@ function renderParagraphWithoutComments(node: Element, parserOptions: HTMLReactP
   );
 }
 
+function ImageParagraphWithoutComments({
+  src,
+  alt,
+}: {
+  src: string;
+  alt: string;
+}) {
+  const isMobile = useContext(IsMobileContext) ?? false;
+  return <ImageParagraph src={src} alt={alt} isMobile={isMobile} />;
+}
+
+function ImageParagraphWithComments({
+  src,
+  alt,
+  postId,
+  paragraphId,
+  paragraphIndex,
+  coAuthorUserId,
+  isAdmin,
+  initialCount,
+}: {
+  src: string;
+  alt: string;
+  postId: string;
+  paragraphId: string;
+  paragraphIndex: number;
+  coAuthorUserId?: string | null;
+  isAdmin: boolean;
+  initialCount: number;
+}) {
+  const isMobile = useContext(IsMobileContext) ?? false;
+
+  const commentSlot = (
+    <LazyParagraphCommentWidget
+      postId={postId}
+      paragraphId={paragraphId}
+      paragraphIndex={paragraphIndex}
+      coAuthorUserId={coAuthorUserId}
+      isAdmin={isAdmin}
+      isMobile={isMobile}
+      initialCount={initialCount}
+      paragraphProps={{}}
+    >
+      <span />
+    </LazyParagraphCommentWidget>
+  );
+
+  return (
+    <ImageParagraph
+      src={src}
+      alt={alt}
+      isMobile={isMobile}
+      paragraphCommentSlot={commentSlot}
+      initialCommentCount={initialCount}
+    />
+  );
+}
+
 type PostContentClientProps = {
+
   postId: string;
   date: string;
   htmlContent: string;
@@ -107,6 +168,19 @@ export default function PostContentClient({
 
   const parserOptions: HTMLReactParserOptions = {};
 
+  function extractSingleImage(node: Element): { src: string; alt: string } | null {
+    const children = (node.children ?? []).filter(
+      (c: any) => c.type !== "text" || c.data?.trim() !== "",
+    );
+    if (children.length !== 1) return null;
+    const child = children[0] as any;
+    if (child.type !== "tag" || child.name !== "img") return null;
+    const src = child.attribs?.src ?? "";
+    const alt = child.attribs?.alt ?? "";
+    if (!src) return null;
+    return { src, alt };
+  }
+
   parserOptions.replace = (node: DOMNode): ReplaceReturn => {
     if (node.type === "tag" && node.name === "span") {
       const element = node as Element;
@@ -125,6 +199,42 @@ export default function PostContentClient({
         if (kind === "co-author") {
           return <AutorReference kind="co-author" coAuthorImageUrl={coAuthorImageUrl ?? null} />;
         }
+      }
+    }
+
+    if (node.type === "tag" && node.name === "p" && !isEditing) {
+      const element = node as Element;
+      const imageData = extractSingleImage(element);
+
+      if (imageData) {
+        const currentIndex = paragraphIndex;
+        paragraphIndex += 1;
+        const paragraphId = `${postId}-paragraph-${currentIndex}`;
+        const initialCount = summaryMap.get(paragraphId) ?? 0;
+
+        if (paragraphCommentsEnabled) {
+          return (
+            <ImageParagraphWithComments
+              key={paragraphId}
+              src={imageData.src}
+              alt={imageData.alt}
+              postId={postId}
+              paragraphId={paragraphId}
+              paragraphIndex={currentIndex}
+              coAuthorUserId={coAuthorUserId}
+              isAdmin={isAdmin}
+              initialCount={initialCount}
+            />
+          );
+        }
+
+        return (
+          <ImageParagraphWithoutComments
+            key={paragraphId}
+            src={imageData.src}
+            alt={imageData.alt}
+          />
+        );
       }
     }
 

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -221,7 +221,7 @@ export function LazyParagraphCommentWidget(props: ParagraphCommentWidgetProps) {
   return <Widget {...restProps} isMobile={isMobile} autoOpen={pendingOpen} />;
 }
 
-const IsMobileContext = createContext<boolean | null>(null);
+export const IsMobileContext = createContext<boolean | null>(null);
 
 export function useIsMobile(): boolean {
   const context = useContext(IsMobileContext);


### PR DESCRIPTION
### Motivation

- Support richer handling of single-image paragraphs by providing a native lightbox on desktop and an inline comment drawer on mobile. 
- Surface paragraph comment counts for image-only paragraphs and allow images to host the existing paragraph comment widget. 
- Make `IsMobileContext` available to other modules so image rendering can adapt to mobile/desktop behavior.

### Description

- Add `components/ImageParagraph.tsx` which implements an image component with a desktop lightbox, mobile inline comment drawer, close controls, and a comment-count badge. 
- Detect single-image paragraphs in `src/app/posts/[id]/post-content-client.tsx` via the new `extractSingleImage` helper and render either `ImageParagraphWithComments` or `ImageParagraphWithoutComments` depending on `paragraphCommentsEnabled`. 
- Integrate the existing `LazyParagraphCommentWidget` as a `paragraphCommentSlot` inside the image drawer so paragraph comment functionality is reusable for images. 
- Export `IsMobileContext` from `post-content-interactive.tsx` and use `useContext(IsMobileContext)` where needed, plus adjust imports to include `useContext` and import the new `ImageParagraph` component. 

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) to validate typings and imports, which completed successfully. 
- Ran the test suite via `pnpm test` (project test runner) and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c04a0c708322b6764427e3a541ca)