### PR TITLE
Rebuild ImageParagraph with unified fullscreen lightbox

### DIFF
--- a/components/ImageParagraph.tsx
+++ b/components/ImageParagraph.tsx
@@ -6,119 +6,161 @@ import { XMarkIcon } from "@heroicons/react/24/solid";
 type ImageParagraphProps = {
   src: string;
   alt: string;
-  isMobile: boolean;
+  isMobile?: boolean;
   paragraphCommentSlot?: React.ReactNode;
   initialCommentCount?: number;
 };
 
-export default function ImageParagraph({
-  src,
-  alt,
-  isMobile,
-  paragraphCommentSlot,
-  initialCommentCount = 0,
-}: ImageParagraphProps) {
-  const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [commentsOpen, setCommentsOpen] = useState(false);
-  const lightboxRef = useRef<HTMLDivElement>(null);
+export default function ImageParagraph({ src, alt }: ImageParagraphProps) {
+  const [open, setOpen] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const scrollYOnOpen = useRef(0);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const SCROLL_DISMISS_THRESHOLD = 80;
 
-  const openLightbox = useCallback(() => setLightboxOpen(true), []);
-  const closeLightbox = useCallback(() => setLightboxOpen(false), []);
-  const toggleComments = useCallback(() => setCommentsOpen((v) => !v), []);
+  const openLightbox = useCallback(() => {
+    scrollYOnOpen.current = window.scrollY;
+    setOpen(true);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setVisible(true));
+    });
+  }, []);
 
+  const closeLightbox = useCallback(() => {
+    setVisible(false);
+    setTimeout(() => setOpen(false), 250);
+  }, []);
+
+  // Fecha com Escape
   useEffect(() => {
-    if (!lightboxOpen) return;
+    if (!open) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") closeLightbox();
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [lightboxOpen, closeLightbox]);
+  }, [open, closeLightbox]);
 
+  // Bloqueia scroll do body enquanto aberto
   useEffect(() => {
-    document.body.style.overflow = lightboxOpen ? "hidden" : "";
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = "";
+      document.body.style.overflow = prev;
     };
-  }, [lightboxOpen]);
+  }, [open]);
+
+  // Scroll-to-dismiss: detecta scroll mesmo com body bloqueado
+  useEffect(() => {
+    if (!open) return;
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) > SCROLL_DISMISS_THRESHOLD) closeLightbox();
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      scrollYOnOpen.current = e.touches[0]?.clientY ?? 0;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const delta = Math.abs((e.touches[0]?.clientY ?? 0) - scrollYOnOpen.current);
+      if (delta > SCROLL_DISMISS_THRESHOLD) closeLightbox();
+    };
+    window.addEventListener("wheel", onWheel, { passive: true });
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    return () => {
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+    };
+  }, [open, closeLightbox]);
 
   return (
     <>
-      <span className="relative block group my-2">
+      {/* Imagem inline no post */}
+      <span data-image-paragraph className="relative block group my-2">
         <img
           src={src}
           alt={alt}
-          onClick={isMobile ? toggleComments : openLightbox}
-          className={`
-            rounded-md w-full h-full cursor-zoom-in
-            transition-all duration-300
-            ${commentsOpen ? "grayscale-0" : "grayscale-100"}
-          `}
+          onClick={openLightbox}
+          className="rounded-md w-full h-full cursor-zoom-in"
         />
-
-        {isMobile && initialCommentCount > 0 && !commentsOpen && (
-          <span className="absolute bottom-2 right-2 flex items-center gap-1 rounded-full bg-black/60 px-2 py-0.5 text-[11px] text-white backdrop-blur-sm">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-3" aria-hidden>
-              <path fillRule="evenodd" d="M1 8.74C1 10.55 2.46 12 4.26 12H5v1.52a.75.75 0 0 0 1.14.642L9.11 12h2.63A3.25 3.25 0 0 0 15 8.74v-2.5A3.25 3.25 0 0 0 11.74 3H4.26A3.25 3.25 0 0 0 1 6.24v2.5Z" clipRule="evenodd" />
-            </svg>
-            {initialCommentCount}
-          </span>
-        )}
-
-        {!isMobile && (
-          <span className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-full bg-black/60 p-1.5 backdrop-blur-sm pointer-events-none">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-3 text-white" aria-hidden>
-              <path d="M6 1a5 5 0 1 1 0 10A5 5 0 0 1 6 1Zm.75 4.25v-1.5a.75.75 0 0 0-1.5 0v1.5h-1.5a.75.75 0 0 0 0 1.5h1.5v1.5a.75.75 0 0 0 1.5 0v-1.5h1.5a.75.75 0 0 0 0-1.5h-1.5ZM13.78 13.78a.75.75 0 0 1-1.06 0L10.22 11.28A6 6 0 1 1 11.28 10.22l2.5 2.5a.75.75 0 0 1 0 1.06Z" />
-            </svg>
-          </span>
-        )}
+        {/* Ícone de zoom */}
+        <span className="absolute bottom-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-full bg-black/60 p-1.5 backdrop-blur-sm pointer-events-none">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="size-3 text-white" aria-hidden>
+            <path d="M6 1a5 5 0 1 1 0 10A5 5 0 0 1 6 1Zm.75 4.25v-1.5a.75.75 0 0 0-1.5 0v1.5h-1.5a.75.75 0 0 0 0 1.5h1.5v1.5a.75.75 0 0 0 1.5 0v-1.5h1.5a.75.75 0 0 0 0-1.5h-1.5ZM13.78 13.78a.75.75 0 0 1-1.06 0L10.22 11.28A6 6 0 1 1 11.28 10.22l2.5 2.5a.75.75 0 0 1 0 1.06Z" />
+          </svg>
+        </span>
       </span>
 
-      {isMobile && commentsOpen && (
-        <div className="rounded-2xl overflow-hidden border border-zinc-200 dark:border-zinc-800 shadow-lg mb-2">
-          <div className="relative bg-zinc-950">
-            <img
-              src={src}
-              alt={alt}
-              className="w-full h-auto max-h-64 object-contain grayscale-0"
-            />
-            <button
-              type="button"
-              onClick={toggleComments}
-              aria-label="Fechar"
-              className="absolute top-2 right-2 flex items-center justify-center rounded-full bg-black/60 p-1.5 backdrop-blur-sm"
-            >
-              <XMarkIcon className="h-4 w-4 text-white" />
-            </button>
-          </div>
-
-          <div className="p-3">{paragraphCommentSlot}</div>
-        </div>
-      )}
-
-      {lightboxOpen && (
+      {/* Lightbox — fullscreen, mobile e desktop */}
+      {open && (
         <div
-          ref={lightboxRef}
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/90 backdrop-blur-sm"
+          ref={overlayRef}
           onClick={(e) => {
-            if (e.target === lightboxRef.current) closeLightbox();
+            if (e.target === overlayRef.current) closeLightbox();
+          }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center"
+          style={{
+            backgroundColor: `rgba(0,0,0,${visible ? 0.92 : 0})`,
+            backdropFilter: `blur(${visible ? 8 : 0}px)`,
+            transition: "background-color 250ms ease, backdrop-filter 250ms ease",
           }}
         >
+          {/* Botão fechar */}
           <button
             type="button"
             onClick={closeLightbox}
             aria-label="Fechar"
-            className="absolute top-4 right-4 flex items-center justify-center rounded-full bg-white/10 p-2 transition-colors hover:bg-white/20"
+            className="absolute top-4 right-4 z-10 flex items-center justify-center rounded-full bg-white/10 p-2 transition-colors hover:bg-white/20"
+            style={{
+              opacity: visible ? 1 : 0,
+              transition: "opacity 250ms ease",
+            }}
           >
             <XMarkIcon className="h-5 w-5 text-white" />
           </button>
+
+          {/* Imagem */}
           <img
             src={src}
             alt={alt}
-            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain grayscale-0 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+            style={{
+              filter: "grayscale(0)",
+              opacity: visible ? 1 : 0,
+              transform: visible ? "scale(1)" : "scale(0.92)",
+              transition: "opacity 250ms ease, transform 250ms ease",
+            }}
           />
+
+          {/* Dica de fechar — some após 2s */}
+          <DismissHint visible={visible} />
         </div>
       )}
     </>
+  );
+}
+
+function DismissHint({ visible }: { visible: boolean }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!visible) return;
+    setShow(true);
+    const t = setTimeout(() => setShow(false), 2000);
+    return () => clearTimeout(t);
+  }, [visible]);
+
+  return (
+    <span
+      className="absolute bottom-6 left-1/2 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/70 backdrop-blur-sm pointer-events-none"
+      style={{
+        opacity: show ? 1 : 0,
+        transition: "opacity 400ms ease",
+      }}
+    >
+      Scroll ou Esc para fechar
+    </span>
   );
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -88,6 +88,11 @@ ul {
 }
 img {
   @apply rounded-md grayscale-100 w-full h-full;
+  transition: filter 300ms ease;
+}
+
+[data-image-paragraph]:hover img {
+  filter: grayscale(0);
 }
 h4 {
   @apply lg:text-3xl max-sm:text-xl font-bold;


### PR DESCRIPTION
### Motivation
- Unify mobile and desktop image interactions into a single fullscreen lightbox and simplify the component behavior.
- Improve open/close animations and add reliable dismissal UX (Escape, click-outside, scroll/touch) for better accessibility and discoverability.
- Fix hover grayscale specificity issues by controlling hover in global CSS via a data attribute.

### Description
- Rewrote `components/ImageParagraph.tsx` to implement a unified fullscreen lightbox with animated open/close (opacity + scale, 250ms), `Escape` to close, and click-outside handling via `overlayRef`.
- Added scroll-to-dismiss handling using `wheel` and touch events with an 80px threshold and locked body scroll while the lightbox is open.
- Preserved `ImageParagraphProps` compatibility (`isMobile`, `paragraphCommentSlot`, `initialCommentCount`) but removed the legacy inline/mobile comment panel behavior, and added `data-image-paragraph` to the inline wrapper while simplifying the inline image classes.
- Updated `src/app/global.css` to add `transition: filter 300ms ease` to the global `img` rule and to apply `[data-image-paragraph]:hover img { filter: grayscale(0); }` to resolve Tailwind specificity conflicts.

### Testing
- Ran `npx tsc --noEmit`, which failed due to pre-existing TypeScript typing errors in `tests/post-reference.test.tsx` unrelated to these changes.
- Started the dev server with `npm run dev`, which launched but the root page returned an error because `MONGODB_URI` and `MONGODB_DB` were not provided in the environment.
- Executed a Playwright script to load `http://127.0.0.1:3000` and capture a screenshot, which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8cc31fde483228ccf7b331bb8c0b7)