### PR TITLE
Add real reading-time API and client hook, wire into post header

### DIFF
--- a/components/useRealReadingTime.ts
+++ b/components/useRealReadingTime.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+function formatSeconds(seconds: number): string {
+  if (seconds < 60) return "menos de 1 min";
+  const minutes = Math.round(seconds / 60);
+  return `${minutes} min`;
+}
+
+export function useRealReadingTime(
+  postId: string,
+  estimatedReadingTime: string
+): string {
+  const [readingTime, setReadingTime] = useState(estimatedReadingTime);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/posts/${encodeURIComponent(postId)}/reading-time`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data.available && data.totalSeconds > 0) {
+          setReadingTime(formatSeconds(data.totalSeconds));
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [postId]);
+
+  return readingTime;
+}

--- a/src/app/api/posts/[id]/reading-time/route.ts
+++ b/src/app/api/posts/[id]/reading-time/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { getMongoDb } from "@lib/mongo";
+
+const MIN_SESSIONS = 25;
+const SECTIONS = 10;
+const CAP_SECONDS = 120;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params;
+  if (!postId) {
+    return NextResponse.json({ error: "postId required" }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  const events = db.collection("analytics_events");
+
+  // Conta sessões distintas com dados de atenção para este post
+  const distinctSessions = await events.distinct("session", {
+    name: "section_attention",
+    "data.postId": postId,
+  });
+
+  if (distinctSessions.length < MIN_SESSIONS) {
+    return NextResponse.json({ available: false }, { status: 200 });
+  }
+
+  // Calcula média de segundos por seção entre sessões distintas
+  const rows = await events
+    .aggregate<{ section: number; avgSeconds: number }>([
+      { $match: { name: "section_attention", "data.postId": postId } },
+      {
+        $group: {
+          _id: { session: "$session", section: "$data.section" },
+          sessionSeconds: { $sum: "$data.seconds" },
+        },
+      },
+      {
+        $project: {
+          section: "$_id.section",
+          sessionSeconds: { $min: ["$sessionSeconds", CAP_SECONDS] },
+        },
+      },
+      {
+        $group: {
+          _id: "$section",
+          avgSeconds: { $avg: "$sessionSeconds" },
+        },
+      },
+      { $project: { _id: 0, section: "$_id", avgSeconds: 1 } },
+      { $sort: { section: 1 } },
+    ])
+    .toArray();
+
+  // Garante todos os 10 buckets
+  const map = new Map(rows.map((r) => [r.section, r.avgSeconds]));
+  const sections = Array.from({ length: SECTIONS }, (_, i) => ({
+    section: i,
+    avgSeconds: map.get(i) ?? 0,
+  }));
+
+  const totalSeconds = Math.round(
+    sections.reduce((acc, s) => acc + s.avgSeconds, 0)
+  );
+
+  return NextResponse.json(
+    { available: true, totalSeconds, sessions: distinctSessions.length },
+    { status: 200 }
+  );
+}

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -19,6 +19,7 @@ import {
 } from "react";
 import { Date } from "@components/date";
 import ShareButton from "@components/ShareButton";
+import { useRealReadingTime } from "@components/useRealReadingTime";
 import AudioPlayer from "@components/AudioPlayer";
 import PostMinimap from "@components/PostMinimap";
 import { EyeIcon, ClockIcon } from "@heroicons/react/24/solid";
@@ -259,6 +260,7 @@ export default function PostContentShell({
   contentRef,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
+  const displayReadingTime = useRealReadingTime(postId, readingTime);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
@@ -320,7 +322,7 @@ export default function PostContentShell({
               <span className="inline-flex items-center gap-1">
                 <ClockIcon className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">Tempo de leitura:</span>
-                {readingTime}
+                {displayReadingTime}
               </span>
               <span aria-hidden className="mx-1 text-zinc-400">•</span>
               <span className="inline-flex items-center gap-1">
@@ -337,7 +339,7 @@ export default function PostContentShell({
         </div>
       </div>
     ),
-    [date, hideShareButton, postId, readingTime, views],
+    [date, displayReadingTime, hideShareButton, postId, views],
   );
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,6 +28,7 @@ const isPublicApiRoute = createRouteMatcher([
   "/api/posts/shorten-url",
   "/api/posts/(.*)/attention-heatmap",
   "/api/posts/(.*)",
+  "/api/posts/(.*)/reading-time",
   "/api/search-posts",
   "/api/comments(.*)",
   "/api/post-references(.*)",


### PR DESCRIPTION
### Motivation

- Provide a more accurate reading-time estimate based on aggregated attention analytics rather than the static estimated value.

### Description

- Adds a server API route `GET /api/posts/[id]/reading-time` that aggregates `section_attention` events from MongoDB, enforces a minimum session threshold, caps per-section seconds, and returns `available`, `totalSeconds`, and `sessions`.
- Adds a client hook `useRealReadingTime` that fetches the reading-time API for a post and falls back to the provided `estimatedReadingTime` until real data is available, formatting seconds into a readable string.
- Integrates the hook into the post UI by replacing the static `readingTime` display with the `useRealReadingTime` result in `PostContentShell` and updates dependencies for the header memo accordingly.
- Updates middleware public API route matcher to allow unauthenticated access to the new `/api/posts/(.*)/reading-time` endpoint.

### Testing

- Type-check run with `tsc --noEmit` completed successfully.
- Local Next.js build via `next build` completed without errors.
- ESLint check (`pnpm lint`) passed with no new issues detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a95a4302f08322ad49fa4e949617ae)