### PR TITLE
Add paragraph highlighting feature (client UI, hook, and API)

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import type { Highlight } from "./useHighlights";
+
+type Props = {
+  paragraphId: string;
+  postId: string;
+  highlights: Highlight[];
+  onHighlightSaved: (h: Highlight) => void;
+  onHighlightDeleted: (id: string) => void;
+  paragraphProps?: HTMLAttributes<HTMLElement>;
+  children: ReactNode;
+  userId: string | null | undefined;
+};
+
+type SelectionInfo = {
+  selectedText: string;
+  startOffset: number;
+  endOffset: number;
+  x: number;
+  y: number;
+};
+
+export default function HighlightedParagraph({
+  paragraphId,
+  postId,
+  highlights,
+  onHighlightSaved,
+  onHighlightDeleted,
+  paragraphProps,
+  children,
+  userId,
+}: Props) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const [selection, setSelection] = useState<SelectionInfo | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [myHighlight, setMyHighlight] = useState<Highlight | null>(null);
+
+  useEffect(() => {
+    const mine = highlights.find(
+      (h) => h.paragraphId === paragraphId && h.userId === userId
+    );
+    setMyHighlight(mine ?? null);
+  }, [highlights, paragraphId, userId]);
+
+  const handleMouseUp = useCallback(() => {
+    if (!userId) return;
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !sel.rangeCount) {
+      setSelection(null);
+      return;
+    }
+
+    const range = sel.getRangeAt(0);
+    const container = containerRef.current;
+    if (!container || !container.contains(range.commonAncestorContainer)) {
+      setSelection(null);
+      return;
+    }
+
+    const selectedText = sel.toString().trim();
+    if (!selectedText) {
+      setSelection(null);
+      return;
+    }
+
+    const preRange = document.createRange();
+    preRange.setStart(container, 0);
+    preRange.setEnd(range.startContainer, range.startOffset);
+    const startOffset = preRange.toString().length;
+    const endOffset = startOffset + selectedText.length;
+
+    const rect = range.getBoundingClientRect();
+    setSelection({
+      selectedText,
+      startOffset,
+      endOffset,
+      x: rect.left + rect.width / 2,
+      y: rect.top + window.scrollY - 8,
+    });
+  }, [userId]);
+
+  const saveHighlight = useCallback(async () => {
+    if (!selection || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch(
+        `/api/posts/${encodeURIComponent(postId)}/paragraph-highlights`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            paragraphId,
+            selectedText: selection.selectedText,
+            startOffset: selection.startOffset,
+            endOffset: selection.endOffset,
+          }),
+        }
+      );
+      if (!res.ok) throw new Error(await res.text());
+      const { highlight } = await res.json();
+      onHighlightSaved(highlight);
+      setSelection(null);
+      window.getSelection()?.removeAllRanges();
+    } catch (e) {
+      console.error("Failed to save highlight", e);
+    } finally {
+      setSaving(false);
+    }
+  }, [selection, saving, postId, paragraphId, onHighlightSaved]);
+
+  const deleteHighlight = useCallback(async () => {
+    if (!myHighlight) return;
+    try {
+      await fetch(`/api/posts/${encodeURIComponent(postId)}/paragraph-highlights`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ highlightId: myHighlight._id }),
+      });
+      onHighlightDeleted(myHighlight._id);
+    } catch (e) {
+      console.error("Failed to delete highlight", e);
+    }
+  }, [myHighlight, postId, onHighlightDeleted]);
+
+  useEffect(() => {
+    if (!selection) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (!containerRef.current?.contains(target)) {
+        setSelection(null);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [selection]);
+
+  const otherHighlights = highlights.filter(
+    (h) => h.paragraphId === paragraphId && h.userId !== userId
+  );
+  const highlightCount = otherHighlights.length + (myHighlight ? 1 : 0);
+
+  return (
+    <span className="relative block">
+      <span
+        {...paragraphProps}
+        ref={containerRef}
+        onMouseUp={handleMouseUp}
+        onTouchEnd={handleMouseUp}
+        className={[
+          paragraphProps?.className,
+          myHighlight ? "border-l-2 border-yellow-400/60 pl-2" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {children}
+
+        {highlightCount > 0 && (
+          <span
+            className="ml-2 inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
+            title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
+          >
+            ✦ {highlightCount}
+          </span>
+        )}
+      </span>
+
+      {selection && userId && (
+        <span
+          className="fixed z-[9998] -translate-x-1/2 -translate-y-full"
+          style={{ left: selection.x, top: selection.y }}
+        >
+          <span className="flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1.5 shadow-lg ring-1 ring-zinc-700">
+            <button
+              type="button"
+              onClick={saveHighlight}
+              disabled={saving}
+              className="flex items-center gap-1 text-xs font-medium text-yellow-300 hover:text-yellow-200 disabled:opacity-50"
+            >
+              <span aria-hidden>✦</span>
+              {saving ? "Salvando…" : "Destacar"}
+            </button>
+            {myHighlight && (
+              <>
+                <span className="mx-1 text-zinc-600" aria-hidden>
+                  |
+                </span>
+                <button
+                  type="button"
+                  onClick={deleteHighlight}
+                  className="text-xs text-zinc-400 hover:text-red-400"
+                >
+                  Remover
+                </button>
+              </>
+            )}
+          </span>
+          <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-zinc-900" />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/paragraph-comments/useHighlights.ts
+++ b/components/paragraph-comments/useHighlights.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type Highlight = {
+  _id: string;
+  postId: string;
+  paragraphId: string;
+  userId: string;
+  authorName: string;
+  selectedText: string;
+  startOffset: number;
+  endOffset: number;
+  createdAt: string;
+};
+
+export function useHighlights(postId: string) {
+  const [highlights, setHighlights] = useState<Highlight[]>([]);
+  const loaded = useRef(false);
+
+  useEffect(() => {
+    if (loaded.current) return;
+    loaded.current = true;
+
+    fetch(`/api/posts/${encodeURIComponent(postId)}/paragraph-highlights`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) setHighlights(data);
+      })
+      .catch(() => {});
+  }, [postId]);
+
+  const addHighlight = useCallback((h: Highlight) => {
+    setHighlights((prev) => {
+      const filtered = prev.filter(
+        (p) => !(p.userId === h.userId && p.paragraphId === h.paragraphId)
+      );
+      return [...filtered, h];
+    });
+  }, []);
+
+  const removeHighlight = useCallback((highlightId: string) => {
+    setHighlights((prev) => prev.filter((h) => h._id !== highlightId));
+  }, []);
+
+  return { highlights, addHighlight, removeHighlight };
+}

--- a/src/app/api/posts/[id]/paragraph-highlights/route.ts
+++ b/src/app/api/posts/[id]/paragraph-highlights/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { ObjectId } from "mongodb";
+
+import { getMongoDb } from "@lib/mongo";
+import { resolveAdminStatus } from "@lib/admin";
+
+const COLLECTION = "paragraph-highlights";
+const MAX_LENGTH = 300;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params;
+  if (!postId) {
+    return NextResponse.json({ error: "postId required" }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  const docs = await db
+    .collection(COLLECTION)
+    .find({ postId })
+    .sort({ createdAt: 1 })
+    .toArray();
+
+  return NextResponse.json(
+    docs.map((d: any) => ({
+      _id: d._id.toString(),
+      postId: d.postId,
+      paragraphId: d.paragraphId,
+      userId: d.userId,
+      authorName: d.authorName,
+      selectedText: d.selectedText,
+      startOffset: d.startOffset,
+      endOffset: d.endOffset,
+      createdAt: d.createdAt,
+    })),
+    { status: 200 }
+  );
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params;
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Não autorizado." }, { status: 401 });
+  }
+
+  const user = await currentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Usuário não encontrado." }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Payload inválido." }, { status: 400 });
+  }
+
+  const { paragraphId, selectedText, startOffset, endOffset } = body as any;
+
+  if (
+    !paragraphId ||
+    !selectedText ||
+    typeof startOffset !== "number" ||
+    typeof endOffset !== "number"
+  ) {
+    return NextResponse.json({ error: "Dados insuficientes." }, { status: 400 });
+  }
+
+  if (selectedText.trim().length === 0 || selectedText.length > MAX_LENGTH) {
+    return NextResponse.json(
+      { error: `Destaque deve ter entre 1 e ${MAX_LENGTH} caracteres.` },
+      { status: 400 }
+    );
+  }
+
+  const db = await getMongoDb();
+
+  await db.collection(COLLECTION).deleteOne({ postId, paragraphId, userId });
+
+  const doc = {
+    postId,
+    paragraphId,
+    userId,
+    authorName: user.fullName || user.firstName || user.username || "Leitor",
+    selectedText: selectedText.trim(),
+    startOffset,
+    endOffset,
+    createdAt: new Date().toISOString(),
+  };
+
+  const result = await db.collection(COLLECTION).insertOne(doc);
+
+  return NextResponse.json(
+    { highlight: { ...doc, _id: result.insertedId.toString() } },
+    { status: 201 }
+  );
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: postId } = await params;
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Não autorizado." }, { status: 401 });
+  }
+
+  const { isAdmin } = await resolveAdminStatus();
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Payload inválido." }, { status: 400 });
+  }
+
+  const { highlightId } = body as any;
+  if (!highlightId) {
+    return NextResponse.json({ error: "highlightId required." }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  let objectId: ObjectId;
+  try {
+    objectId = new ObjectId(highlightId);
+  } catch {
+    return NextResponse.json({ error: "highlightId inválido." }, { status: 400 });
+  }
+  const doc = await db.collection(COLLECTION).findOne({ _id: objectId, postId });
+
+  if (!doc) {
+    return NextResponse.json({ error: "Não encontrado." }, { status: 404 });
+  }
+
+  if (!isAdmin && (doc as any).userId !== userId) {
+    return NextResponse.json({ error: "Não autorizado." }, { status: 403 });
+  }
+
+  await db.collection(COLLECTION).deleteOne({ _id: objectId, postId });
+
+  return NextResponse.json({ deleted: true }, { status: 200 });
+}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -19,6 +19,10 @@ import HeatmapProgressBar from "@components/HeatmapProgressBar";
 import { useContext, type HTMLAttributes, type RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 import ImageParagraph from "@components/ImageParagraph";
+import { useHighlights } from "@components/paragraph-comments/useHighlights";
+import HighlightedParagraph from "@components/paragraph-comments/HighlightedParagraph";
+import { useAuth } from "@clerk/nextjs";
+import type { Highlight } from "@components/paragraph-comments/useHighlights";
 
 function renderParagraphWithComments(
   node: Element,
@@ -26,6 +30,12 @@ function renderParagraphWithComments(
   paragraphIndex: number,
   options: Pick<ParagraphCommentWidgetProps, "postId" | "coAuthorUserId" | "isAdmin">,
   summaryMap: Map<string, number>,
+  highlightProps?: {
+    highlights: Highlight[];
+    userId: string | null | undefined;
+    onHighlightSaved: (h: Highlight) => void;
+    onHighlightDeleted: (id: string) => void;
+  }
 ) {
   const paragraphId = `${options.postId}-paragraph-${paragraphIndex}`;
   const initialCount = summaryMap.get(paragraphId) ?? 0;
@@ -40,6 +50,36 @@ function renderParagraphWithComments(
       .join(" "),
   };
 
+  const content = domToReact((node.children ?? []) as DOMNode[], parserOptions);
+
+  if (highlightProps) {
+    return (
+      <HighlightedParagraph
+        key={paragraphId}
+        paragraphId={paragraphId}
+        postId={options.postId}
+        highlights={highlightProps.highlights}
+        userId={highlightProps.userId}
+        onHighlightSaved={highlightProps.onHighlightSaved}
+        onHighlightDeleted={highlightProps.onHighlightDeleted}
+        paragraphProps={enhancedParagraphProps}
+      >
+        <LazyParagraphCommentWidget
+          postId={options.postId}
+          paragraphId={paragraphId}
+          paragraphIndex={paragraphIndex}
+          coAuthorUserId={options.coAuthorUserId}
+          paragraphProps={{}}
+          isAdmin={options.isAdmin}
+          isMobile={false}
+          initialCount={initialCount}
+        >
+          {content}
+        </LazyParagraphCommentWidget>
+      </HighlightedParagraph>
+    );
+  }
+
   return (
     <LazyParagraphCommentWidget
       key={paragraphId}
@@ -52,7 +92,7 @@ function renderParagraphWithComments(
       isMobile={false}
       initialCount={initialCount}
     >
-      {domToReact((node.children ?? []) as DOMNode[], parserOptions)}
+      {content}
     </LazyParagraphCommentWidget>
   );
 }
@@ -161,7 +201,9 @@ export default function PostContentClient({
   isEditing = false,
   contentRef,
 }: PostContentClientProps) {
+  const { userId } = useAuth();
   const summaryMap = useCommentsSummary(postId);
+  const { highlights, addHighlight, removeHighlight } = useHighlights(postId);
   let paragraphIndex = 0;
 
   type ReplaceReturn = ReturnType<NonNullable<HTMLReactParserOptions["replace"]>>;
@@ -243,11 +285,19 @@ export default function PostContentClient({
       const currentIndex = paragraphIndex;
       paragraphIndex += 1;
 
-      return renderParagraphWithComments(element, parserOptions, currentIndex, {
-        postId,
-        coAuthorUserId,
-        isAdmin,
-      }, summaryMap);
+      return renderParagraphWithComments(
+        element,
+        parserOptions,
+        currentIndex,
+        { postId, coAuthorUserId, isAdmin },
+        summaryMap,
+        {
+          highlights,
+          userId,
+          onHighlightSaved: addHighlight,
+          onHighlightDeleted: removeHighlight,
+        }
+      );
     }
 
     if (node.type === "tag" && node.name === "p" && !paragraphCommentsEnabled) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,6 +29,7 @@ const isPublicApiRoute = createRouteMatcher([
   "/api/posts/(.*)/attention-heatmap",
   "/api/posts/(.*)",
   "/api/posts/(.*)/reading-time",
+  "/api/posts/(.*)/paragraph-highlights",
   "/api/search-posts",
   "/api/comments(.*)",
   "/api/post-references(.*)",


### PR DESCRIPTION
### Motivation

- Enable readers to highlight selections inside post paragraphs, persist them per-user, and show per-paragraph highlight counts.

### Description

- Add a client component `HighlightedParagraph` to capture text selection, show a floating action bar, and allow saving/removing highlights. 
- Add `useHighlights` hook to fetch and manage highlights for a given `postId` on the client. 
- Implement server API at `src/app/api/posts/[id]/paragraph-highlights/route.ts` with `GET`, `POST`, and `DELETE` handlers that validate input, enforce authentication, limit highlight length, dedupe per-user per-paragraph, and persist to the `paragraph-highlights` MongoDB collection. 
- Integrate highlights into the post renderer by updating `post-content-client.tsx` to use `useAuth`, `useHighlights`, and render `HighlightedParagraph` for paragraph nodes, and update middleware to allow the new API route. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9668f86188322bcf67ab981fb75db)