### PR TITLE
Remove unnecessary outer wrapper in HighlightedParagraph

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -149,14 +149,15 @@ export default function HighlightedParagraph({
   const highlightCount = otherHighlights.length + (myHighlight ? 1 : 0);
 
   return (
-    <span className="relative block">
+    <>
       <span
-        {...paragraphProps}
+        {...(paragraphProps as any)}
         ref={containerRef}
         onMouseUp={handleMouseUp}
         onTouchEnd={handleMouseUp}
         className={[
-          paragraphProps?.className,
+          (paragraphProps as any)?.className,
+          "relative",
           myHighlight ? "border-l-2 border-yellow-400/60 pl-2" : "",
         ]
           .filter(Boolean)
@@ -207,6 +208,6 @@ export default function HighlightedParagraph({
           <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-zinc-900" />
         </span>
       )}
-    </span>
+    </>
   );
 }


### PR DESCRIPTION
### Motivation
- The outer `<span className="relative block">` was breaking paragraph flow and creating visual gaps even when no highlight was active, so it needed removal to preserve normal text layout.

### Description
- Replaced the outer wrapper with a fragment by changing the component root to `<>...</>` and keeping the floating selection UI intact.
- Moved the `relative` positioning class into the inner paragraph span's `className` array so that positioning is preserved without forcing a block-level wrapper.
- Cast `paragraphProps` to `any` when spreading and when reading `className` via `{...(paragraphProps as any)}` and `(paragraphProps as any)?.className` to satisfy the updated prop spreading.

### Testing
- Ran `npx tsc --noEmit`, which failed due to pre-existing test typing errors in `tests/post-reference.test.tsx` unrelated to this change.
- Ran `npm run dev`, which started the Next.js dev server successfully for local validation.
- Attempted a Playwright screenshot to validate visually, but the Chromium process crashed with a SIGSEGV in this environment, so automated screenshot validation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96db788c08322a46253587aaef8d4)