### PR TITLE
Fix highlight popover close behavior on internal clicks

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -135,9 +135,14 @@ export default function HighlightedParagraph({
     if (!selection) return;
     const onDown = (e: MouseEvent) => {
       const target = e.target as Node;
-      if (!containerRef.current?.contains(target)) {
-        setSelection(null);
+      // Não fecha se o clique foi no próprio popover
+      if (
+        containerRef.current?.contains(target) ||
+        (target as Element).closest?.("[data-highlight-popover]")
+      ) {
+        return;
       }
+      setSelection(null);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
@@ -177,6 +182,7 @@ export default function HighlightedParagraph({
 
       {selection && userId && (
         <span
+          data-highlight-popover
           className="fixed z-[9998] -translate-x-1/2 -translate-y-full"
           style={{ left: selection.x, top: selection.y }}
         >


### PR DESCRIPTION
### Motivation
- Evitar que o listener de `mousedown` feche o popover antes do `onClick` dos botões do popover, já que `mousedown` ocorre antes do `click` no fluxo de eventos do navegador.

### Description
- Atualiza o `useEffect` de outside-click em `components/paragraph-comments/HighlightedParagraph.tsx` para ignorar cliques que ocorram dentro do próprio popover verificando `closest("[data-highlight-popover]")`.
- Adiciona o atributo `data-highlight-popover` no elemento wrapper do popover para que o listener consiga detectar e ignorar cliques internos.
- Mantém o comportamento de fechar o popover quando o clique estiver fora do parágrafo e fora do popover.

### Testing
- Nenhum teste automatizado foi executado pois trata-se de um ajuste pontual de lógica de UI; mudanças foram verificadas localmente via diff e commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97575cbe08322bffe3e1e3a8fae9f)