### PR TITLE
Add mobile highlight UI and comments open registration for paragraphs

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -19,6 +19,8 @@ type Props = {
   paragraphProps?: HTMLAttributes<HTMLElement>;
   children: ReactNode;
   userId: string | null | undefined;
+  onOpenComments?: () => void;
+  isMobile?: boolean;
 };
 
 type SelectionInfo = {
@@ -38,11 +40,15 @@ export default function HighlightedParagraph({
   paragraphProps,
   children,
   userId,
+  onOpenComments,
+  isMobile = false,
 }: Props) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [saving, setSaving] = useState(false);
   const [myHighlight, setMyHighlight] = useState<Highlight | null>(null);
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const [mobileMenuPos, setMobileMenuPos] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
     const mine = highlights.find(
@@ -117,6 +123,36 @@ export default function HighlightedParagraph({
     }
   }, [selection, saving, postId, paragraphId, onHighlightSaved]);
 
+  const highlightFullParagraph = useCallback(async () => {
+    if (!userId || saving) return;
+    const fullText = containerRef.current?.textContent?.trim() ?? "";
+    if (!fullText) return;
+    setSaving(true);
+    try {
+      const res = await fetch(
+        `/api/posts/${encodeURIComponent(postId)}/paragraph-highlights`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            paragraphId,
+            selectedText: fullText,
+            startOffset: 0,
+            endOffset: fullText.length,
+          }),
+        }
+      );
+      if (!res.ok) throw new Error(await res.text());
+      const { highlight } = await res.json();
+      onHighlightSaved(highlight);
+      setShowMobileMenu(false);
+    } catch (e) {
+      console.error("Failed to save highlight", e);
+    } finally {
+      setSaving(false);
+    }
+  }, [userId, saving, postId, paragraphId, onHighlightSaved]);
+
   const deleteHighlight = useCallback(async () => {
     if (!myHighlight) return;
     try {
@@ -132,10 +168,9 @@ export default function HighlightedParagraph({
   }, [myHighlight, postId, onHighlightDeleted]);
 
   useEffect(() => {
-    if (!selection) return;
+    if (!selection && !showMobileMenu) return;
     const onDown = (e: MouseEvent) => {
       const target = e.target as Node;
-      // Não fecha se o clique foi no próprio popover
       if (
         containerRef.current?.contains(target) ||
         (target as Element).closest?.("[data-highlight-popover]")
@@ -143,10 +178,11 @@ export default function HighlightedParagraph({
         return;
       }
       setSelection(null);
+      setShowMobileMenu(false);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
-  }, [selection]);
+  }, [selection, showMobileMenu]);
 
   const otherHighlights = highlights.filter(
     (h) => h.paragraphId === paragraphId && h.userId !== userId
@@ -159,7 +195,15 @@ export default function HighlightedParagraph({
         {...(paragraphProps as any)}
         ref={containerRef}
         onMouseUp={handleMouseUp}
-        onTouchEnd={handleMouseUp}
+        onTouchEnd={(e) => {
+          if (isMobile && userId) {
+            const touch = e.changedTouches[0];
+            setMobileMenuPos({ x: touch.clientX, y: touch.clientY + window.scrollY - 8 });
+            setShowMobileMenu((v) => !v);
+            return;
+          }
+          handleMouseUp();
+        }}
         className={[
           (paragraphProps as any)?.className,
           "relative",
@@ -180,36 +224,96 @@ export default function HighlightedParagraph({
         )}
       </span>
 
-      {selection && userId && (
+      {isMobile && showMobileMenu && userId && mobileMenuPos && (
+        <span
+          data-highlight-popover
+          className="fixed z-[9998] -translate-x-1/2 -translate-y-full"
+          style={{ left: mobileMenuPos.x, top: mobileMenuPos.y }}
+        >
+          <span className="flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1.5 shadow-lg ring-1 ring-zinc-700">
+            {!myHighlight ? (
+              <button
+                type="button"
+                onClick={() => void highlightFullParagraph()}
+                disabled={saving}
+                className="flex items-center gap-1 text-xs font-medium text-yellow-300 hover:text-yellow-200 disabled:opacity-50"
+              >
+                <span aria-hidden>✦</span>
+                {saving ? "Salvando…" : "Destacar"}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  void deleteHighlight();
+                  setShowMobileMenu(false);
+                }}
+                className="flex items-center gap-1 text-xs font-medium text-red-400 hover:text-red-300"
+              >
+                <span aria-hidden>✦</span>
+                Remover destaque
+              </button>
+            )}
+            <span className="mx-1 text-zinc-600" aria-hidden>
+              |
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                setShowMobileMenu(false);
+                onOpenComments?.();
+              }}
+              className="flex items-center gap-1 text-xs font-medium text-zinc-300 hover:text-white"
+            >
+              Comentar
+            </button>
+          </span>
+          <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-zinc-900" />
+        </span>
+      )}
+
+      {!isMobile && selection && userId && (
         <span
           data-highlight-popover
           className="fixed z-[9998] -translate-x-1/2 -translate-y-full"
           style={{ left: selection.x, top: selection.y }}
         >
           <span className="flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1.5 shadow-lg ring-1 ring-zinc-700">
+            {!myHighlight && (
+              <button
+                type="button"
+                onClick={saveHighlight}
+                disabled={saving}
+                className="flex items-center gap-1 text-xs font-medium text-yellow-300 hover:text-yellow-200 disabled:opacity-50"
+              >
+                <span aria-hidden>✦</span>
+                {saving ? "Salvando…" : "Destacar"}
+              </button>
+            )}
+            {myHighlight && (
+              <button
+                type="button"
+                onClick={deleteHighlight}
+                className="flex items-center gap-1 text-xs font-medium text-red-400 hover:text-red-300"
+              >
+                <span aria-hidden>✦</span>
+                Remover
+              </button>
+            )}
+            <span className="mx-1 text-zinc-600" aria-hidden>
+              |
+            </span>
             <button
               type="button"
-              onClick={saveHighlight}
-              disabled={saving}
-              className="flex items-center gap-1 text-xs font-medium text-yellow-300 hover:text-yellow-200 disabled:opacity-50"
+              onClick={() => {
+                setSelection(null);
+                window.getSelection()?.removeAllRanges();
+                onOpenComments?.();
+              }}
+              className="flex items-center gap-1 text-xs font-medium text-zinc-300 hover:text-white"
             >
-              <span aria-hidden>✦</span>
-              {saving ? "Salvando…" : "Destacar"}
+              Comentar
             </button>
-            {myHighlight && (
-              <>
-                <span className="mx-1 text-zinc-600" aria-hidden>
-                  |
-                </span>
-                <button
-                  type="button"
-                  onClick={deleteHighlight}
-                  className="text-xs text-zinc-400 hover:text-red-400"
-                >
-                  Remover
-                </button>
-              </>
-            )}
           </span>
           <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-zinc-900" />
         </span>

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -51,6 +51,7 @@ type ParagraphCommentWidgetProps = {
   isMobile: boolean;
   initialCount?: number;
   autoOpen?: boolean;
+  onRegisterOpenComments?: (fn: () => Promise<void>) => void;
 };
 
 export default function ParagraphCommentWidget({
@@ -64,6 +65,7 @@ export default function ParagraphCommentWidget({
   isMobile,
   initialCount = 0,
   autoOpen = false,
+  onRegisterOpenComments,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -379,6 +381,10 @@ export default function ParagraphCommentWidget({
 
     setIsExpanded(next);
   }, [hasLoaded, isLoaded, loadComments, openLoginPrompt, paragraphId, userId]);
+
+  useEffect(() => {
+    onRegisterOpenComments?.(openComments);
+  }, [onRegisterOpenComments, openComments]);
 
   useEffect(() => {
     if (!isLoaded || queuedExpand === null) {
@@ -700,10 +706,8 @@ export default function ParagraphCommentWidget({
             {...restParagraphProps}
             tabIndex={0}
             onClick={(e) => {
-            incomingOnClick?.(e);
-            if ((e as React.MouseEvent<HTMLParagraphElement>).defaultPrevented) return;
-            if (isMobile) void openComments();
-          }}
+              incomingOnClick?.(e);
+            }}
           onFocus={(e) => {
             incomingOnFocus?.(e);
             if ((e as React.FocusEvent<HTMLParagraphElement>).defaultPrevented) return;
@@ -941,4 +945,3 @@ export default function ParagraphCommentWidget({
     </>
   );
 }
-

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -16,7 +16,7 @@ import PostContentShell, {
 } from "./post-content-interactive";
 import SectionAttentionTracker from "@components/analytics/SectionAttentionTracker";
 import HeatmapProgressBar from "@components/HeatmapProgressBar";
-import { useContext, type HTMLAttributes, type RefObject } from "react";
+import { useContext, useRef, type HTMLAttributes, type RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 import ImageParagraph from "@components/ImageParagraph";
 import { useHighlights } from "@components/paragraph-comments/useHighlights";
@@ -33,6 +33,8 @@ function renderParagraphWithComments(
   highlightProps?: {
     highlights: Highlight[];
     userId: string | null | undefined;
+    isMobile: boolean;
+    openCommentsFnsRef: RefObject<Map<string, () => Promise<void>>>;
     onHighlightSaved: (h: Highlight) => void;
     onHighlightDeleted: (id: string) => void;
   }
@@ -63,6 +65,8 @@ function renderParagraphWithComments(
         onHighlightSaved={highlightProps.onHighlightSaved}
         onHighlightDeleted={highlightProps.onHighlightDeleted}
         paragraphProps={enhancedParagraphProps}
+        isMobile={highlightProps.isMobile}
+        onOpenComments={() => highlightProps.openCommentsFnsRef.current?.get(paragraphId)?.()}
       >
         <LazyParagraphCommentWidget
           postId={options.postId}
@@ -71,8 +75,9 @@ function renderParagraphWithComments(
           coAuthorUserId={options.coAuthorUserId}
           paragraphProps={{}}
           isAdmin={options.isAdmin}
-          isMobile={false}
+          isMobile={highlightProps.isMobile}
           initialCount={initialCount}
+          onRegisterOpenComments={(fn) => highlightProps.openCommentsFnsRef.current?.set(paragraphId, fn)}
         >
           {content}
         </LazyParagraphCommentWidget>
@@ -202,8 +207,10 @@ export default function PostContentClient({
   contentRef,
 }: PostContentClientProps) {
   const { userId } = useAuth();
+  const isMobile = useContext(IsMobileContext) ?? false;
   const summaryMap = useCommentsSummary(postId);
   const { highlights, addHighlight, removeHighlight } = useHighlights(postId);
+  const openCommentsFnsRef = useRef<Map<string, () => Promise<void>>>(new Map());
   let paragraphIndex = 0;
 
   type ReplaceReturn = ReturnType<NonNullable<HTMLReactParserOptions["replace"]>>;
@@ -294,6 +301,8 @@ export default function PostContentClient({
         {
           highlights,
           userId,
+          isMobile,
+          openCommentsFnsRef,
           onHighlightSaved: addHighlight,
           onHighlightDeleted: removeHighlight,
         }

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -35,6 +35,7 @@ export type ParagraphCommentWidgetProps = {
   isMobile: boolean;
   initialCount?: number;
   autoOpen?: boolean;
+  onRegisterOpenComments?: (fn: () => Promise<void>) => void;
 };
 
 export type ParagraphCommentWidgetComponent = ComponentType<ParagraphCommentWidgetProps>;


### PR DESCRIPTION
### Motivation

- Improve mobile UX by providing a touch-friendly menu to highlight or comment on entire paragraphs. 
- Allow the paragraph comment widget to expose a programmatic `openComments` function so external controls (like the mobile highlight menu) can open the comment thread for a specific paragraph. 
- Surface highlight state consistently between desktop selection popover and the new mobile flow. 

### Description

- Added `isMobile` and `onOpenComments` props to `HighlightedParagraph` and implemented a touch handler to show a fixed mobile menu at the touch position that can `highlight` the full paragraph or `comment` (invoking `onOpenComments`).
- Implemented `highlightFullParagraph` to submit a full-paragraph highlight and adjusted selection/popover logic to handle both mobile and desktop flows, including separate popover rendering and close behavior. 
- Added `onRegisterOpenComments` prop to `ParagraphCommentWidget` and registered the internal `openComments` callback in an effect so callers can store and trigger it remotely. 
- Threaded an `openCommentsFnsRef` through `post-content-client` to maintain a map of paragraph ids to `openComments` functions and passed `isMobile` context into paragraph rendering to enable the mobile behavior. 

### Testing

- TypeScript type check via `npm run typecheck` completed successfully. 
- Local dev build/start via `npm run dev` launched without runtime type errors on manual smoke testing. 
- Existing automated test suite via `npm test` was executed and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97e4935d8832291f201e04441c81d)