### PR TITLE
Add desktop ✦ Destacar action next to paragraph comments

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -52,6 +52,7 @@ type ParagraphCommentWidgetProps = {
   initialCount?: number;
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
+  onHighlight?: () => void;
 };
 
 export default function ParagraphCommentWidget({
@@ -66,6 +67,7 @@ export default function ParagraphCommentWidget({
   initialCount = 0,
   autoOpen = false,
   onRegisterOpenComments,
+  onHighlight,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -727,14 +729,26 @@ export default function ParagraphCommentWidget({
           {children}
         </p>
         <span aria-hidden="true" className="hidden md:block absolute right-[-2rem] top-0 h-full w-8 pointer-events-none" />
-        <button
-          type="button"
-          onClick={toggleComments}
-          className="hidden md:inline-flex pointer-events-none absolute right-[-2rem] top-1/2 z-10 -translate-y-1/2 opacity-0 transition-opacity peer-hover:opacity-100 group-hover:opacity-100 hover:opacity-100 focus:opacity-100 peer-hover:pointer-events-auto group-hover:pointer-events-auto hover:pointer-events-auto focus:pointer-events-auto md:inline-flex shrink-0 items-center gap-1 rounded-full border border-zinc-300 bg-white px-3 py-1 text-sm font-medium text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"
-          aria-label="Comentar parágrafo"
-        >
-          <ChatBubbleLeftRightIcon className="h-4 w-4" />
-        </button>
+        <span className="hidden md:flex pointer-events-none absolute right-[-2rem] top-1/2 z-10 -translate-y-1/2 translate-x-full opacity-0 transition-opacity peer-hover:opacity-100 group-hover:opacity-100 peer-hover:pointer-events-auto group-hover:pointer-events-auto items-center gap-1">
+          {onHighlight && (
+            <button
+              type="button"
+              onClick={onHighlight}
+              className="shrink-0 flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2.5 py-1 text-sm font-medium text-yellow-500 shadow-sm hover:border-zinc-400 hover:text-yellow-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-yellow-400 dark:hover:border-zinc-500"
+              aria-label="Destacar parágrafo"
+            >
+              ✦
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={toggleComments}
+            className="shrink-0 flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2.5 py-1 text-sm font-medium text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"
+            aria-label="Comentar parágrafo"
+          >
+            <ChatBubbleLeftRightIcon className="h-4 w-4" />
+          </button>
+        </span>
         {!isExpanded && displayCount > 0 && (
           <span className="absolute right-[-2rem] top-1/2 -translate-y-1/2">
             <CommentIndicator

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -78,6 +78,40 @@ function renderParagraphWithComments(
           isMobile={highlightProps.isMobile}
           initialCount={initialCount}
           onRegisterOpenComments={(fn) => highlightProps.openCommentsFnsRef.current?.set(paragraphId, fn)}
+          onHighlight={() => {
+            if (!highlightProps.userId) {
+              return;
+            }
+            const paragraphText = document
+              .querySelector(`[data-paragraph-id="${paragraphId}"] p`)
+              ?.textContent?.trim();
+            if (!paragraphText) {
+              return;
+            }
+
+            void fetch(`/api/posts/${encodeURIComponent(options.postId)}/paragraph-highlights`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                paragraphId,
+                selectedText: paragraphText,
+                startOffset: 0,
+                endOffset: paragraphText.length,
+              }),
+            })
+              .then(async (response) => {
+                if (!response.ok) {
+                  throw new Error(await response.text());
+                }
+                return response.json() as Promise<{ highlight: Highlight }>;
+              })
+              .then((data) => {
+                highlightProps.onHighlightSaved(data.highlight);
+              })
+              .catch((error) => {
+                console.error("Failed to save highlight", error);
+              });
+          }}
         >
           {content}
         </LazyParagraphCommentWidget>

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -36,6 +36,7 @@ export type ParagraphCommentWidgetProps = {
   initialCount?: number;
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
+  onHighlight?: () => void;
 };
 
 export type ParagraphCommentWidgetComponent = ComponentType<ParagraphCommentWidgetProps>;


### PR DESCRIPTION
### Motivation

- Provide a quick desktop hover action to highlight ("Destacar") a full paragraph next to the existing comment action so users can mark important paragraphs from the hover UI.
- Ensure the UI and codepath can persist a full-paragraph highlight and sync it into the local highlights state.

### Description

- Added an optional `onHighlight` prop to `ParagraphCommentWidget` and the `ParagraphCommentWidgetProps` type used by the lazy loader so the widget can receive a highlight action callback.
- Replaced the single desktop hover comment button with a two-button action group that conditionally shows a `✦` highlight button and the existing comment button in `components/paragraph-comments/ParagraphCommentWidget.tsx`.
- Wired `onHighlight` into `src/app/posts/[id]/post-content-client.tsx` for highlighted paragraphs to POST a full-paragraph highlight to `/api/posts/{id}/paragraph-highlights` and call `highlightProps.onHighlightSaved` on success to update local highlight state.
- Updated the shared `post-content-interactive.tsx` prop type to include `onHighlight` so the lazy widget accepts the new prop.

### Testing

- Ran `npx tsc --noEmit`, which failed due to pre-existing TypeScript errors in `tests/post-reference.test.tsx` that are unrelated to this change.
- Started the app with `npm run dev`, which successfully launched Next.js but runtime rendering of `/` failed due to missing environment variables (`MONGODB_URI` / `MONGODB_DB`) unrelated to these edits.
- Executed a Playwright script against the running dev server to hover a paragraph and capture a screenshot, which succeeded and produced the artifact `artifacts/highlight-comment-hover.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a982e28c448322b4d89eb9c92dd41c)