### PR TITLE
Ajusta posição e hover dos botões de comentário no desktop

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -729,7 +729,7 @@ export default function ParagraphCommentWidget({
           {children}
         </p>
         <span aria-hidden="true" className="hidden md:block absolute right-[-2rem] top-0 h-full w-8 pointer-events-none" />
-        <span className="hidden md:flex pointer-events-none absolute right-[-2rem] top-1/2 z-10 -translate-y-1/2 translate-x-full opacity-0 transition-opacity peer-hover:opacity-100 group-hover:opacity-100 peer-hover:pointer-events-auto group-hover:pointer-events-auto items-center gap-1">
+        <span className="hidden md:flex pointer-events-none absolute right-0 top-1/2 z-10 -translate-y-1/2 translate-x-[calc(100%+0.5rem)] opacity-0 transition-opacity peer-hover:opacity-100 group-hover:opacity-100 hover:opacity-100 peer-hover:pointer-events-auto group-hover:pointer-events-auto hover:pointer-events-auto items-center gap-0.5">
           {onHighlight && (
             <button
               type="button"


### PR DESCRIPTION
### Motivation
- Corrigir posicionamento e comportamento de hover dos botões de comentário no desktop para que fiquem colados ao parágrafo e não sumam ao mover o cursor entre parágrafo e botões.

### Description
- Atualizei a `span` de controle em `components/paragraph-comments/ParagraphCommentWidget.tsx`, trocando `right-[-2rem]` + `translate-x-full` por `right-0` + `translate-x-[calc(100%+0.5rem)]`, reduzindo `gap-1` para `gap-0.5` e adicionando `hover:opacity-100` e `hover:pointer-events-auto` para manter o hover ativo ao mover o mouse para os botões.

### Testing
- Rodei `npm run build`, que parou na coleta de dados por falta das variáveis de ambiente `MONGODB_URI` e `MONGODB_DB`, portanto a build não pôde ser concluída no ambiente CI local disponível.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98579d74c8322899de1528bbc1ad9)