### PR TITLE
Ajusta comentários/destaques de parágrafo no mobile

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -43,7 +43,7 @@ export default function HighlightedParagraph({
   onOpenComments,
   isMobile = false,
 }: Props) {
-  const containerRef = useRef<HTMLSpanElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [saving, setSaving] = useState(false);
   const [myHighlight, setMyHighlight] = useState<Highlight | null>(null);
@@ -213,7 +213,7 @@ export default function HighlightedParagraph({
 
   return (
     <>
-      <span
+      <div
         {...(paragraphProps as any)}
         ref={containerRef}
         onMouseUp={handleMouseUp}
@@ -256,7 +256,7 @@ export default function HighlightedParagraph({
             ✦ {highlightCount}
           </span>
         )}
-      </span>
+      </div>
 
       {isMobile && showMobileMenu && mobileMenuPos && (
         <span

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -817,7 +817,7 @@ export default function ParagraphCommentWidget({
               </button>
             )}
           </span>
-          {!isExpanded && displayCount > 0 && (
+          {!isExpanded && displayCount > 0 && !isMobile && (
             <span className="absolute right-[-2rem] top-1/2 -translate-y-1/2">
               <CommentIndicator count={displayCount} onClick={toggleComments} />
             </span>


### PR DESCRIPTION
### Motivation
- Corrigir comportamento no mobile para que tocar em um parágrafo abra o menu de comentar/destacar sem depender de seleção de texto.
- Evitar que o ícone indicador de comentário quebre a interface em telas pequenas, exibindo-o apenas no desktop.

### Description
- Troca o wrapper de `HighlightedParagraph` de `span` para `div` e atualiza o `ref` para `HTMLDivElement` para suportar corretamente os handlers de toque/ clique.  
- Mantém os handlers `onTouchEnd` e `onClick` no container para abrir o menu mobile ao tocar no parágrafo.  
- Ajusta `ParagraphCommentWidget` para não renderizar o `CommentIndicator` quando `isMobile` é `true` (adiciona a verificação `!isMobile`).

### Testing
- `npx tsc --noEmit` foi executado e falhou por erros pré-existentes em `tests/post-reference.test.tsx`, não relacionados a esta alteração.  
- `npm run dev` levantou o servidor com sucesso, mas a rota `/` apresentou erro em tempo de execução devido a variáveis de ambiente ausentes (`MONGODB_URI` e `MONGODB_DB`).  
- Capturas visuais por Playwright foram geradas para mobile e desktop com sucesso (artifacts: `browser:/tmp/codex_browser_invocations/bfcd5b5329b11f97/artifacts/artifacts/mobile-paragraph-comments.png` e `browser:/tmp/codex_browser_invocations/a8314868329fdd26/artifacts/artifacts/desktop-paragraph-comments.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98ffc141c8328972e8ed16c0003e3)