### PR TITLE
Improve touch/compact UI handling for paragraph highlights and comments

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -43,7 +43,7 @@ export default function HighlightedParagraph({
   onOpenComments,
   isMobile = false,
 }: Props) {
-  const containerRef = useRef<HTMLSpanElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
   const [saving, setSaving] = useState(false);
   const [myHighlight, setMyHighlight] = useState<Highlight | null>(null);
@@ -52,6 +52,27 @@ export default function HighlightedParagraph({
     x: number;
     y: number;
   } | null>(null);
+  const [useTouchActions, setUseTouchActions] = useState(isMobile);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const media = window.matchMedia("(hover: none), (pointer: coarse), (max-width: 767px)");
+    const update = () => {
+      setUseTouchActions(isMobile || media.matches || navigator.maxTouchPoints > 0);
+    };
+
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [isMobile]);
+
+  const openTouchMenuAt = useCallback((x: number, y: number) => {
+    setSelection(null);
+    window.getSelection()?.removeAllRanges();
+    setMobileMenuPos({ x, y });
+    setShowMobileMenu(true);
+  }, []);
 
   useEffect(() => {
     const mine = highlights.find(
@@ -213,30 +234,19 @@ export default function HighlightedParagraph({
 
   return (
     <>
-      <span
+      <div
         {...(paragraphProps as any)}
         ref={containerRef}
         onMouseUp={handleMouseUp}
         onTouchEnd={(e) => {
-          if (isMobile) {
-            const touch = e.changedTouches[0];
-            setMobileMenuPos({
-              x: touch.clientX,
-              y: touch.clientY + window.scrollY - 8,
-            });
-            setShowMobileMenu(true);
-            return;
-          }
-          handleMouseUp();
+          const touch = e.changedTouches[0];
+          if (!touch) return;
+          openTouchMenuAt(touch.clientX, touch.clientY + window.scrollY - 8);
         }}
         onClick={(e) => {
-          if (!isMobile) return;
+          if (!useTouchActions) return;
           const event = e.nativeEvent as MouseEvent;
-          setMobileMenuPos({
-            x: event.clientX,
-            y: event.clientY + window.scrollY - 8,
-          });
-          setShowMobileMenu(true);
+          openTouchMenuAt(event.clientX, event.clientY + window.scrollY - 8);
         }}
         className={[
           (paragraphProps as any)?.className,
@@ -256,9 +266,9 @@ export default function HighlightedParagraph({
             ✦ {highlightCount}
           </span>
         )}
-      </span>
+      </div>
 
-      {isMobile && showMobileMenu && mobileMenuPos && (
+      {showMobileMenu && mobileMenuPos && (
         <span
           data-highlight-popover
           className="fixed z-[9998] -translate-x-1/2 -translate-y-full"

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -112,8 +112,22 @@ export default function ParagraphCommentWidget({
   const undoIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [isUndoingDelete, setIsUndoingDelete] = useState(false);
   const [localDelta, setLocalDelta] = useState(0);
+  const [useCompactUi, setUseCompactUi] = useState(isMobile);
   const displayCount = hasLoaded ? comments.length : initialCount + localDelta;
   const { trackEvent, isTrackingEnabled } = useAnalytics();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const media = window.matchMedia("(hover: none), (pointer: coarse), (max-width: 767px)");
+    const update = () => {
+      setUseCompactUi(isMobile || media.matches || navigator.maxTouchPoints > 0);
+    };
+
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, [isMobile]);
 
   const clearPendingDeleteTimeout = useCallback(() => {
     if (pendingDeleteTimeoutRef.current) {
@@ -817,7 +831,7 @@ export default function ParagraphCommentWidget({
               </button>
             )}
           </span>
-          {!isExpanded && displayCount > 0 && (
+          {!isExpanded && displayCount > 0 && !useCompactUi && (
             <span className="absolute right-[-2rem] top-1/2 -translate-y-1/2">
               <CommentIndicator count={displayCount} onClick={toggleComments} />
             </span>


### PR DESCRIPTION
### Motivation
- Make paragraph highlighting and comment UI behave correctly on touch devices and small viewports by detecting touch-capable environments instead of relying solely on `isMobile` prop.
- Provide a compact UI mode that hides the inline comment indicator on touch/compact devices to reduce visual clutter.

### Description
- Change the paragraph container from a `span` to a `div` and update the `containerRef` type accordingly to better support event handling and positioning.
- Add a `matchMedia`-based detection effect (and `navigator.maxTouchPoints` check) to both components to set `useTouchActions` and `useCompactUi` states for touch/compact environments, with automatic updates on media changes.
- Introduce `openTouchMenuAt` to centralize opening the touch menu, clear selection, and position the mobile menu; update `onTouchEnd` and `onClick` in `HighlightedParagraph` to use this helper and gate click behavior on `useTouchActions` instead of `isMobile`.
- Remove the previous `isMobile` gating for rendering the mobile menu so it displays whenever `showMobileMenu` is set, and hide the inline comment indicator in `ParagraphCommentWidget` when `useCompactUi` is true.

### Testing
- Ran a TypeScript build (`yarn build`) to ensure types compile and the ref type change is correct, and it succeeded.
- Ran the test suite (`yarn test`) and the tests passed.
- Ran linting (`yarn lint`) and formatting checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98ffc141c8328972e8ed16c0003e3)