### PR TITLE
Fixar menu móvel de destaque no canto superior direito do parágrafo

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -67,10 +67,15 @@ export default function HighlightedParagraph({
     return () => media.removeEventListener("change", update);
   }, [isMobile]);
 
-  const openTouchMenuAt = useCallback((x: number, y: number) => {
+  const openTouchMenuAt = useCallback(() => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
     setSelection(null);
     window.getSelection()?.removeAllRanges();
-    setMobileMenuPos({ x, y });
+    setMobileMenuPos({
+      x: rect.right,
+      y: rect.top + window.scrollY - 8,
+    });
     setShowMobileMenu(true);
   }, []);
 
@@ -239,14 +244,12 @@ export default function HighlightedParagraph({
         ref={containerRef}
         onMouseUp={handleMouseUp}
         onTouchEnd={(e) => {
-          const touch = e.changedTouches[0];
-          if (!touch) return;
-          openTouchMenuAt(touch.clientX, touch.clientY + window.scrollY - 8);
+          if (!e.changedTouches[0]) return;
+          openTouchMenuAt();
         }}
         onClick={(e) => {
           if (!useTouchActions) return;
-          const event = e.nativeEvent as MouseEvent;
-          openTouchMenuAt(event.clientX, event.clientY + window.scrollY - 8);
+          openTouchMenuAt();
         }}
         className={[
           (paragraphProps as any)?.className,
@@ -271,7 +274,7 @@ export default function HighlightedParagraph({
       {showMobileMenu && mobileMenuPos && (
         <span
           data-highlight-popover
-          className="fixed z-[9998] -translate-x-1/2 -translate-y-full"
+          className="fixed z-[9998] -translate-x-full -translate-y-full"
           style={{ left: mobileMenuPos.x, top: mobileMenuPos.y }}
         >
           <span className="flex items-center gap-1 rounded-full bg-zinc-900 px-3 py-1.5 shadow-lg ring-1 ring-zinc-700">


### PR DESCRIPTION
### Motivation

- O menu móvel usava as coordenadas do toque/clique, o que fazia sua posição variar e por vezes vazar da tela; a intenção é ancorá-lo sempre ao canto superior direito do parágrafo.

### Description

- Alterei `openTouchMenuAt` para não receber parâmetros e calcular a posição via `containerRef.current.getBoundingClientRect()` atribuindo `x: rect.right` e `y: rect.top + window.scrollY - 8`.
- Atualizei os handlers `onTouchEnd` e `onClick` para chamar `openTouchMenuAt()` sem argumentos em vez de passar `clientX/clientY`.
- Ajustei o popover móvel para usar `-translate-x-full` em vez de `-translate-x-1/2` para ancoragem à direita e evitar estouro da tela; as mudanças estão em `components/paragraph-comments/HighlightedParagraph.tsx` e foram commitadas.

### Testing

- Executei `npm run build`, que compilou mas falhou ao coletar page data por falta de variáveis de ambiente (`MONGODB_URI` e `MONGODB_DB`).
- Iniciei o modo dev com `MONGODB_URI='mongodb://localhost:27017' MONGODB_DB='test' npm run dev`, o servidor iniciou e compilou com sucesso em modo desenvolvimento.
- Tentei capturar uma screenshot com Playwright, porém o Chromium travou (SIGSEGV) no ambiente de container, impedindo validação visual automatizada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99e1ee0e0832888bfccf457b3cdb5)