### PR TITLE
Fix mobile menu vertical position in HighlightedParagraph

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -74,7 +74,7 @@ export default function HighlightedParagraph({
     window.getSelection()?.removeAllRanges();
     setMobileMenuPos({
       x: rect.right,
-      y: rect.top + window.scrollY - 8,
+      y: rect.top - 8,
     });
     setShowMobileMenu(true);
   }, []);


### PR DESCRIPTION
### Motivation
- Fix misplacement of the mobile touch menu caused by adding `window.scrollY` to `getBoundingClientRect().top`, which produced an incorrect y-coordinate when the page was scrolled.

### Description
- Adjusted `setMobileMenuPos` in `components/paragraph-comments/HighlightedParagraph.tsx` to use `rect.top - 8` instead of `rect.top + window.scrollY - 8` so the mobile menu is positioned correctly relative to the viewport.

### Testing
- Ran the frontend automated test suite and component tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a2e95e2083289a8ef82e074779e4)