### PR TITLE
Move highlight badge out of paragraph and enable comment indicator in compact UI

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -260,16 +260,16 @@ export default function HighlightedParagraph({
           .join(" ")}
       >
         {children}
-
-        {highlightCount > 0 && (
-          <span
-            className="ml-2 inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
-            title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
-          >
-            ✦ {highlightCount}
-          </span>
-        )}
       </div>
+
+      {highlightCount > 0 && (
+        <span
+          className="flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default w-fit"
+          title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
+        >
+          ✦ {highlightCount}
+        </span>
+      )}
 
       {showMobileMenu && mobileMenuPos && (
         <span

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -831,10 +831,16 @@ export default function ParagraphCommentWidget({
               </button>
             )}
           </span>
-          {!isExpanded && displayCount > 0 && !useCompactUi && (
-            <span className="absolute right-[-2rem] top-1/2 -translate-y-1/2">
-              <CommentIndicator count={displayCount} onClick={toggleComments} />
-            </span>
+          {!isExpanded && displayCount > 0 && (
+            useCompactUi ? (
+              <span className="flex justify-start">
+                <CommentIndicator count={displayCount} onClick={toggleComments} />
+              </span>
+            ) : (
+              <span className="absolute left-0 -translate-x-full top-1/2 -translate-y-1/2 pr-1">
+                <CommentIndicator count={displayCount} onClick={toggleComments} />
+              </span>
+            )
           )}
         </div>
 


### PR DESCRIPTION
### Motivation

- Prevent the highlight count badge from affecting paragraph layout and ensure it fits without overflow. 
- Surface the comment indicator in the `useCompactUi` variant so comment counts are visible in compact layouts. 
- Align indicator placement logic to be consistent between regular and compact displays.

### Description

- In `HighlightedParagraph` the highlight count badge was moved outside the paragraph container and its classes were changed to `flex` with `w-fit` to avoid layout shifts. 
- In `ParagraphCommentWidget` the `CommentIndicator` is now rendered whenever `displayCount > 0` and its placement branches between a left-aligned absolute position for regular UI and a simple inline left-aligned wrapper for `useCompactUi`. 
- Removed the previous `!useCompactUi` gating and adjusted utility classes to reposition the indicator from the right to the left side for better alignment.

### Testing

- Ran a TypeScript type-check and local build with `yarn build`, which completed successfully. 
- Executed the test suite with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a91881208328a1b7757bf123f1c3)