### PR TITLE
Show paragraph highlight badge in comment widget and pass highlight counts from renderer

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -232,11 +232,6 @@ export default function HighlightedParagraph({
     };
   }, [showMobileMenu]);
 
-  const otherHighlights = highlights.filter(
-    (h) => h.paragraphId === paragraphId && h.userId !== userId,
-  );
-  const highlightCount = otherHighlights.length + (myHighlight ? 1 : 0);
-
   return (
     <>
       <div
@@ -261,15 +256,6 @@ export default function HighlightedParagraph({
       >
         {children}
       </div>
-
-      {highlightCount > 0 && (
-        <span
-          className="flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default w-fit"
-          title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
-        >
-          ✦ {highlightCount}
-        </span>
-      )}
 
       {showMobileMenu && mobileMenuPos && (
         <span

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -67,6 +67,7 @@ type ParagraphCommentWidgetProps = {
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
+  highlightCount?: number;
 };
 
 export default function ParagraphCommentWidget({
@@ -82,6 +83,7 @@ export default function ParagraphCommentWidget({
   autoOpen = false,
   onRegisterOpenComments,
   onHighlight,
+  highlightCount = 0,
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -831,14 +833,34 @@ export default function ParagraphCommentWidget({
               </button>
             )}
           </span>
-          {!isExpanded && displayCount > 0 && (
+          {!isExpanded && (displayCount > 0 || highlightCount > 0) && (
             useCompactUi ? (
-              <span className="flex justify-start">
-                <CommentIndicator count={displayCount} onClick={toggleComments} />
+              <span className="flex items-center gap-1 mt-0.5">
+                {highlightCount > 0 && (
+                  <span
+                    className="inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
+                    title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
+                  >
+                    ✦ {highlightCount}
+                  </span>
+                )}
+                {displayCount > 0 && (
+                  <CommentIndicator count={displayCount} onClick={toggleComments} />
+                )}
               </span>
             ) : (
-              <span className="absolute left-0 -translate-x-full top-1/2 -translate-y-1/2 pr-1">
-                <CommentIndicator count={displayCount} onClick={toggleComments} />
+              <span className="absolute left-0 -translate-x-full top-1/2 -translate-y-1/2 pr-1 flex flex-col items-end gap-0.5">
+                {highlightCount > 0 && (
+                  <span
+                    className="inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
+                    title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
+                  >
+                    ✦ {highlightCount}
+                  </span>
+                )}
+                {displayCount > 0 && (
+                  <CommentIndicator count={displayCount} onClick={toggleComments} />
+                )}
               </span>
             )
           )}
@@ -910,11 +932,7 @@ export default function ParagraphCommentWidget({
             </form>
 
             <div className="mt-4 space-y-3">
-              {isLoading ? (
-                <p className="text-sm text-zinc-500">
-                  Carregando comentários...
-                </p>
-              ) : formattedComments.length === 0 ? (
+              {!isLoading && formattedComments.length === 0 ? (
                 <p className="text-sm text-zinc-500">
                   Ainda não há comentários neste parágrafo.
                 </p>

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -112,6 +112,7 @@ function renderParagraphWithComments(
                 console.error("Failed to save highlight", error);
               });
           }}
+          highlightCount={highlightProps.highlights.filter((h) => h.paragraphId === paragraphId).length}
         >
           {content}
         </LazyParagraphCommentWidget>

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -37,6 +37,7 @@ export type ParagraphCommentWidgetProps = {
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
+  highlightCount?: number;
 };
 
 export type ParagraphCommentWidgetComponent =


### PR DESCRIPTION
### Motivation

- Surface per-paragraph highlight counts next to the comment controls so readers can see how many highlights a paragraph has without duplicating UI in the paragraph container.
- Centralize the highlight indicator inside the `ParagraphCommentWidget` to keep paragraph markup simpler and avoid duplicate badges.
- Wire the renderer to compute and pass highlight counts into the widget so the widget can render the badge.

### Description

- Added a new optional prop `highlightCount?: number` to `ParagraphCommentWidget` props and forwarded it through the interactive renderer types.
- Render a yellow highlight badge next to the comment indicator in both the compact and expanded control UIs inside `ParagraphCommentWidget` when `highlightCount > 0`.
- Removed the standalone highlight count ribbon from `HighlightedParagraph.tsx` and now compute and pass the count from `post-content-client.tsx` via `highlightProps.highlights.filter((h) => h.paragraphId === paragraphId).length`.
- Adjusted the comment list rendering branch to no longer show the previous loading text branch (loading now falls through to the list rendering path).

### Testing

- Ran type check and build with `yarn build` (TypeScript compilation) which completed successfully.
- Executed unit tests with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ae8b20348328938cfb231d499dc1)