### PR TITLE
Support joined borders for paragraph highlight + comment badges

### DIFF
--- a/components/paragraph-comments/CommentIndicator.tsx
+++ b/components/paragraph-comments/CommentIndicator.tsx
@@ -4,11 +4,13 @@ import { ChatBubbleLeftRightIcon } from "@heroicons/react/24/outline";
 type Props = {
   count: number;
   onClick: () => void;
+  className?: string;
 };
 
 const CommentIndicator = React.memo(function CommentIndicator({
   count,
   onClick,
+  className,
 }: Props) {
   if (count === 0) return null;
   return (
@@ -16,7 +18,7 @@ const CommentIndicator = React.memo(function CommentIndicator({
       type="button"
       onClick={onClick}
       aria-label={`${count} comentário${count > 1 ? "s" : ""} neste parágrafo`}
-      className="inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-xs font-medium text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"
+      className={className ?? "inline-flex items-center gap-1 rounded-full border border-zinc-300 bg-white px-2 py-0.5 text-xs font-medium text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white"}
     >
       <ChatBubbleLeftRightIcon className="h-3 w-3" />
       {count}

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -835,31 +835,53 @@ export default function ParagraphCommentWidget({
           </span>
           {!isExpanded && (displayCount > 0 || highlightCount > 0) && (
             useCompactUi ? (
-              <span className="flex items-center gap-1 mt-0.5">
+              // Mobile: lado a lado, bordas coladas na horizontal
+              <span className="flex items-center mt-0.5">
                 {highlightCount > 0 && (
                   <span
-                    className="inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
+                    className={[
+                      "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
+                      displayCount > 0 ? "rounded-l-full border-r-0" : "rounded-full",
+                    ].join(" ")}
                     title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
                   >
                     ✦ {highlightCount}
                   </span>
                 )}
                 {displayCount > 0 && (
-                  <CommentIndicator count={displayCount} onClick={toggleComments} />
+                  <CommentIndicator
+                    count={displayCount}
+                    onClick={toggleComments}
+                    className={[
+                      "inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium border border-zinc-300 bg-white text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white",
+                      highlightCount > 0 ? "rounded-r-full" : "rounded-full",
+                    ].join(" ")}
+                  />
                 )}
               </span>
             ) : (
-              <span className="absolute left-0 -translate-x-full top-1/2 -translate-y-1/2 pr-1 flex flex-col items-end gap-0.5">
+              // Desktop: empilhados, bordas coladas na vertical
+              <span className="absolute left-0 -translate-x-full top-1/2 -translate-y-1/2 pr-1 flex flex-col items-end">
                 {highlightCount > 0 && (
                   <span
-                    className="inline-flex items-center gap-0.5 rounded-full bg-yellow-400/20 px-1.5 py-0.5 text-[10px] font-medium text-yellow-700 dark:text-yellow-300 cursor-default"
+                    className={[
+                      "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
+                      displayCount > 0 ? "rounded-t-full border-b-0" : "rounded-full",
+                    ].join(" ")}
                     title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
                   >
                     ✦ {highlightCount}
                   </span>
                 )}
                 {displayCount > 0 && (
-                  <CommentIndicator count={displayCount} onClick={toggleComments} />
+                  <CommentIndicator
+                    count={displayCount}
+                    onClick={toggleComments}
+                    className={[
+                      "inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium border border-zinc-300 bg-white text-zinc-600 shadow-sm hover:border-zinc-400 hover:text-zinc-800 focus-visible:outline-none dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300 dark:hover:border-zinc-500 dark:hover:text-white",
+                      highlightCount > 0 ? "rounded-b-full" : "rounded-full",
+                    ].join(" ")}
+                  />
                 )}
               </span>
             )


### PR DESCRIPTION
### Motivation
- Allow callers to override the default `rounded-full` on the comment badge so highlight and comment badges can be visually joined without duplicate borders.

### Description
- Added an optional `className?: string` prop to `CommentIndicator` and render `className ?? <default>` to preserve backward compatibility.
- Updated the collapsed badge block in `ParagraphCommentWidget` to join the highlight and comment badges: compact/mobile layout joins horizontally with `rounded-l-full`/`rounded-r-full` and no shared border, and desktop layout joins vertically with `rounded-t-full`/`rounded-b-full` and no shared border.
- Single-badge behavior remains the same (still fully rounded).

### Testing
- Ran `npx tsc --noEmit`, which failed due to unrelated pre-existing typing issues in `tests/post-reference.test.tsx` and a missing `@types/react-test-renderer` dependency.
- Started the dev server with `npm run dev` and executed a Playwright script to capture a screenshot for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b2935724832882deb56ff9174512)