### PR TITLE
Adjust paragraph comment highlight badge sizing and click behavior

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -244,6 +244,8 @@ export default function HighlightedParagraph({
         }}
         onClick={(e) => {
           if (!useTouchActions) return;
+          const target = e.target as HTMLElement;
+          if (target.closest("button, a, input, textarea, select, [role='button']")) return;
           openTouchMenuAt();
         }}
         className={[

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -840,7 +840,7 @@ export default function ParagraphCommentWidget({
                 {highlightCount > 0 && (
                   <span
                     className={[
-                      "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
+                      "inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
                       displayCount > 0 ? "rounded-l-full border-r-0" : "rounded-full",
                     ].join(" ")}
                     title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}
@@ -865,7 +865,7 @@ export default function ParagraphCommentWidget({
                 {highlightCount > 0 && (
                   <span
                     className={[
-                      "inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
+                      "inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
                       displayCount > 0 ? "rounded-t-full border-b-0" : "rounded-full",
                     ].join(" ")}
                     title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}


### PR DESCRIPTION
### Motivation
- Equalizar o tamanho do badge de destaque (✦) com o `CommentIndicator` nos dois layouts para consistência visual.
- Evitar que o `onClick` do container de destaque intercepte cliques em elementos interativos (ex.: `textarea`, `button`) para não bloquear interações do widget de comentários.

### Description
- Alteradas as classes do badge ✦ em `components/paragraph-comments/ParagraphCommentWidget.tsx` nos layouts compacto e desktop trocando `gap-0.5` por `gap-1` e `text-[10px]` por `text-xs` para igualar o tamanho ao `CommentIndicator`.
- Atualizado o `onClick` do container em `components/paragraph-comments/HighlightedParagraph.tsx` para checar `target.closest("button, a, input, textarea, select, [role='button']")` e retornar sem abrir o menu quando o clique vier de um elemento interativo.
- Nenhuma outra alteração de comportamento ou arquivo foi feita.

### Testing
- Executado `npx tsc --noEmit`, que falhou por erros TypeScript pré-existentes em testes (`tests/post-reference.test.tsx`) não relacionados a estas mudanças.
- Iniciado o app com `npm run dev`, que subiu o servidor porém a página `/` retornou `500` devido a variáveis de ambiente ausentes (`MONGODB_URI` / `MONGODB_DB`).
- Executado um script Playwright para capturar um screenshot da página em `http://127.0.0.1:3000`, que gerou o artefato de screenshot, embora a página apresentasse erro por falta das variáveis de ambiente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b77ca7388328a9784fa67319839f)