### PR TITLE
Adjust desktop paragraph highlight badge spacing

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -865,7 +865,7 @@ export default function ParagraphCommentWidget({
                 {highlightCount > 0 && (
                   <span
                     className={[
-                      "inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
+                      "inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-yellow-400/20 text-yellow-700 dark:text-yellow-300 cursor-default border border-zinc-300 dark:border-zinc-700",
                       displayCount > 0 ? "rounded-t-full border-b-0" : "rounded-full",
                     ].join(" ")}
                     title={`${highlightCount} destaque${highlightCount > 1 ? "s" : ""} neste parágrafo`}


### PR DESCRIPTION
### Motivation
- Ensure the desktop stacked highlight badge matches the requested size by adjusting its horizontal padding only within the desktop block (`span` with `absolute left-0 -translate-x-full`) while keeping the mobile badge unchanged.

### Description
- In `components/paragraph-comments/ParagraphCommentWidget.tsx` updated the desktop highlight badge class from `px-1.5` to `px-2` inside the desktop stacked block; no other changes were made.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ba338c088328a1093468c217376e)