### PR TITLE
Add mobile highlight style setting with admin toggle and client support

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -255,7 +255,7 @@ export default function HighlightedParagraph({
         className={[
           (paragraphProps as any)?.className,
           "relative",
-          mobileHighlightStyle === "border" && isMobile
+          mobileHighlightStyle === "border"
             ? myHighlight && hasComments
               ? "border-l-2 pl-2"
               : myHighlight
@@ -270,7 +270,7 @@ export default function HighlightedParagraph({
           .filter(Boolean)
           .join(" ")}
         style={
-          mobileHighlightStyle === "border" && isMobile && myHighlight && hasComments
+          mobileHighlightStyle === "border" && myHighlight && hasComments
             ? { borderImage: "linear-gradient(to bottom, #facc15 50%, #a78bfa 50%) 1" }
             : undefined
         }

--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -21,6 +21,8 @@ type Props = {
   userId: string | null | undefined;
   onOpenComments?: () => void;
   isMobile?: boolean;
+  mobileHighlightStyle?: "badges" | "border";
+  hasComments?: boolean;
 };
 
 type SelectionInfo = {
@@ -42,6 +44,8 @@ export default function HighlightedParagraph({
   userId,
   onOpenComments,
   isMobile = false,
+  mobileHighlightStyle = "badges",
+  hasComments = false,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
@@ -251,10 +255,25 @@ export default function HighlightedParagraph({
         className={[
           (paragraphProps as any)?.className,
           "relative",
-          myHighlight ? "border-l-2 border-yellow-400/60 pl-2" : "",
+          mobileHighlightStyle === "border" && isMobile
+            ? myHighlight && hasComments
+              ? "border-l-2 pl-2"
+              : myHighlight
+                ? "border-l-2 border-yellow-400/60 pl-2"
+                : hasComments
+                  ? "border-l-2 border-purple-400/60 pl-2"
+                  : ""
+            : myHighlight
+              ? "border-l-2 border-yellow-400/60 pl-2"
+              : "",
         ]
           .filter(Boolean)
           .join(" ")}
+        style={
+          mobileHighlightStyle === "border" && isMobile && myHighlight && hasComments
+            ? { borderImage: "linear-gradient(to bottom, #facc15 50%, #a78bfa 50%) 1" }
+            : undefined
+        }
       >
         {children}
       </div>

--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -68,6 +68,7 @@ type ParagraphCommentWidgetProps = {
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
   highlightCount?: number;
+  mobileHighlightStyle?: "badges" | "border";
 };
 
 export default function ParagraphCommentWidget({
@@ -84,6 +85,7 @@ export default function ParagraphCommentWidget({
   onRegisterOpenComments,
   onHighlight,
   highlightCount = 0,
+  mobileHighlightStyle = "badges",
 }: ParagraphCommentWidgetProps) {
   const { isLoaded, userId } = useAuth();
   const { openSignIn } = useClerk();
@@ -833,7 +835,8 @@ export default function ParagraphCommentWidget({
               </button>
             )}
           </span>
-          {!isExpanded && (displayCount > 0 || highlightCount > 0) && (
+          {!isExpanded && (displayCount > 0 || highlightCount > 0) &&
+            mobileHighlightStyle !== "border" && (
             useCompactUi ? (
               // Mobile: lado a lado, bordas coladas na horizontal
               <span className="flex items-center mt-0.5">

--- a/src/app/admin/MobileHighlightStyleToggle.tsx
+++ b/src/app/admin/MobileHighlightStyleToggle.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = { initialValue: "badges" | "border" };
+
+export default function MobileHighlightStyleToggle({ initialValue }: Props) {
+  const [value, setValue] = useState(initialValue);
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const update = async (next: "badges" | "border") => {
+    setIsSaving(true);
+    setMessage(null);
+    setError(null);
+    try {
+      const res = await fetch("/admin/api/mobile-highlight-style", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: next }),
+      });
+      if (!res.ok) throw new Error("Erro ao salvar");
+      setValue(next);
+      setMessage("Salvo!");
+    } catch {
+      setError("Erro ao salvar");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-zinc-50">
+            Estilo mobile — destaques de parágrafo
+          </p>
+          <p className="text-xs text-zinc-400">
+            Como indicar destaques e comentários no mobile.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={isSaving}
+            onClick={() => update("badges")}
+            className={[
+              "rounded-full border px-3 py-1 text-xs font-medium transition",
+              value === "badges"
+                ? "border-emerald-500 bg-emerald-500/10 text-emerald-300"
+                : "border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200",
+            ].join(" ")}
+          >
+            Badges
+          </button>
+          <button
+            type="button"
+            disabled={isSaving}
+            onClick={() => update("border")}
+            className={[
+              "rounded-full border px-3 py-1 text-xs font-medium transition",
+              value === "border"
+                ? "border-emerald-500 bg-emerald-500/10 text-emerald-300"
+                : "border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200",
+            ].join(" ")}
+          >
+            Borda
+          </button>
+        </div>
+      </div>
+      <div className="text-xs text-zinc-400">
+        {isSaving && <span className="text-amber-300">Salvando...</span>}
+        {!isSaving && message && <span className="text-emerald-300">{message}</span>}
+        {!isSaving && error && <span className="text-red-400">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -6,6 +6,7 @@ import { resolveAdminStatus } from "@lib/admin";
 import { getFromDate, parseRange, type RangeKey } from "./utils";
 import { getAnalyticsEnabled } from "@lib/analytics/config";
 import { AnalyticsToggle } from "@components/analytics/AnalyticsToggle";
+import MobileHighlightStyleToggle from "../MobileHighlightStyleToggle";
 
 type DeviceBreakdown = { device: string; count: number }[];
 type TopPageRow = {
@@ -15,6 +16,12 @@ type TopPageRow = {
   anonymousViews: number;
   referrer?: string;
 }[];
+
+type MobileHighlightStyleSetting = {
+  _id: string;
+  value?: "badges" | "border";
+};
+
 
 // ---------------------------------------------------------------------------
 // FIX #4a: Wrap all heavy MongoDB aggregate functions with unstable_cache.
@@ -363,7 +370,18 @@ export default async function AdminAnalyticsPage({
   // Serialize to ISO string so unstable_cache key is stable across requests
   const fromIso = from.toISOString();
 
-  const analyticsEnabled = await getAnalyticsEnabled();
+  const [analyticsEnabled, mobileHighlightStyle] = await Promise.all([
+    getAnalyticsEnabled(),
+    getMongoDb()
+      .then((db) =>
+        db
+          .collection<MobileHighlightStyleSetting>("settings")
+          .findOne({ _id: "mobileHighlightStyle" })
+      )
+      .then((highlightStyleDoc) =>
+        (highlightStyleDoc?.value as "badges" | "border") ?? "badges"
+      ),
+  ]);
 
   const [summary, device, topPages, series] = await Promise.all([
     getSummary(fromIso),
@@ -410,6 +428,7 @@ export default async function AdminAnalyticsPage({
       </div>
 
       <AnalyticsToggle initialEnabled={analyticsEnabled} />
+      <MobileHighlightStyleToggle initialValue={mobileHighlightStyle} />
 
       <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
         <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">

--- a/src/app/admin/api/mobile-highlight-style/route.ts
+++ b/src/app/admin/api/mobile-highlight-style/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { getMongoDb } from "@lib/mongo";
+import { resolveAdminStatus } from "@lib/admin";
+
+const SETTING_KEY = "mobileHighlightStyle";
+
+type MobileHighlightStyleSetting = {
+  _id: string;
+  value?: "badges" | "border";
+  updatedAt?: Date;
+};
+
+export async function GET() {
+  const db = await getMongoDb();
+  const doc = await db
+    .collection<MobileHighlightStyleSetting>("settings")
+    .findOne({ _id: SETTING_KEY });
+  return NextResponse.json({ value: doc?.value ?? "badges" });
+}
+
+export async function POST(req: NextRequest) {
+  const { isAdmin } = await resolveAdminStatus();
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { value } = await req.json();
+  if (value !== "badges" && value !== "border") {
+    return NextResponse.json({ error: "Invalid value" }, { status: 400 });
+  }
+
+  const db = await getMongoDb();
+  await db.collection<MobileHighlightStyleSetting>("settings").updateOne(
+    { _id: SETTING_KEY },
+    { $set: { value, updatedAt: new Date() } },
+    { upsert: true }
+  );
+
+  return NextResponse.json({ value });
+}

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -8,6 +8,7 @@ import { renderPostMdx } from "../../../lib/renderers/mdx";
 import { resolveAdminStatus } from "../../../lib/admin";
 import { renderMarkdown } from "../../../lib/renderers/markdown";
 import { normalizeMarkdownContent } from "../../../lib/markdown-normalize";
+import { getMongoDb } from "../../../lib/mongo";
 
 function isStaticGenerationEnvironment(): boolean {
   return process.env.NEXT_PHASE === "phase-production-build";
@@ -37,6 +38,11 @@ type PostDocument = {
 
 type PostPageProps = {
   params: Promise<{ id: string }>;
+};
+
+type MobileHighlightStyleSetting = {
+  _id: string;
+  value?: "badges" | "border";
 };
 
 async function fetchPostById(id: string) {
@@ -220,10 +226,17 @@ export default async function PostPage({ params }: PostPageProps) {
     notFound();
   }
 
-  const [post, isAdmin] = await Promise.all([
+  const [post, isAdmin, highlightStyleDoc] = await Promise.all([
     getPostById(id),
     resolveIsAdmin(),
+    getMongoDb().then((db) =>
+      db
+        .collection<MobileHighlightStyleSetting>("settings")
+        .findOne({ _id: "mobileHighlightStyle" })
+    ),
   ]);
+  const mobileHighlightStyle =
+    (highlightStyleDoc?.value as "badges" | "border") ?? "badges";
 
   if (!post) {
     notFound();
@@ -277,6 +290,7 @@ export default async function PostPage({ params }: PostPageProps) {
         coAuthorUserId={post.coAuthorUserId ?? null}
         coAuthorImageUrl={post.friendImage ?? null}
         paragraphCommentsEnabled={post.paragraphCommentsEnabled ?? false}
+        mobileHighlightStyle={mobileHighlightStyle}
         isAdmin={isAdmin}
         initialMarkdown={normalizedContent}
         tags={post.tags ?? []}

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -34,6 +34,7 @@ function renderParagraphWithComments(
     highlights: Highlight[];
     userId: string | null | undefined;
     isMobile: boolean;
+    mobileHighlightStyle: "badges" | "border";
     openCommentsFnsRef: RefObject<Map<string, () => Promise<void>>>;
     onHighlightSaved: (h: Highlight) => void;
     onHighlightDeleted: (id: string) => void;
@@ -66,6 +67,8 @@ function renderParagraphWithComments(
         onHighlightDeleted={highlightProps.onHighlightDeleted}
         paragraphProps={enhancedParagraphProps}
         isMobile={highlightProps.isMobile}
+        mobileHighlightStyle={highlightProps.mobileHighlightStyle}
+        hasComments={initialCount > 0}
         onOpenComments={() => highlightProps.openCommentsFnsRef.current?.get(paragraphId)?.()}
       >
         <LazyParagraphCommentWidget
@@ -222,6 +225,7 @@ type PostContentClientProps = {
   coAuthorUserId?: string | null;
   coAuthorImageUrl?: string | null;
   paragraphCommentsEnabled: boolean;
+  mobileHighlightStyle?: "badges" | "border";
   isAdmin: boolean;
   isEditing?: boolean;
   contentRef?: RefObject<HTMLDivElement | null>;
@@ -237,6 +241,7 @@ export default function PostContentClient({
   coAuthorUserId,
   coAuthorImageUrl,
   paragraphCommentsEnabled,
+  mobileHighlightStyle,
   isAdmin,
   isEditing = false,
   contentRef,
@@ -337,6 +342,7 @@ export default function PostContentClient({
           highlights,
           userId,
           isMobile,
+          mobileHighlightStyle: mobileHighlightStyle ?? "badges",
           openCommentsFnsRef,
           onHighlightSaved: addHighlight,
           onHighlightDeleted: removeHighlight,

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -28,7 +28,7 @@ function renderParagraphWithComments(
   node: Element,
   parserOptions: HTMLReactParserOptions,
   paragraphIndex: number,
-  options: Pick<ParagraphCommentWidgetProps, "postId" | "coAuthorUserId" | "isAdmin">,
+  options: Pick<ParagraphCommentWidgetProps, "postId" | "coAuthorUserId" | "isAdmin" | "mobileHighlightStyle">,
   summaryMap: Map<string, number>,
   highlightProps?: {
     highlights: Highlight[];
@@ -116,6 +116,7 @@ function renderParagraphWithComments(
               });
           }}
           highlightCount={highlightProps.highlights.filter((h) => h.paragraphId === paragraphId).length}
+          mobileHighlightStyle={highlightProps.mobileHighlightStyle}
         >
           {content}
         </LazyParagraphCommentWidget>
@@ -134,6 +135,7 @@ function renderParagraphWithComments(
       isAdmin={options.isAdmin}
       isMobile={false}
       initialCount={initialCount}
+      mobileHighlightStyle={options.mobileHighlightStyle ?? "badges"}
     >
       {content}
     </LazyParagraphCommentWidget>
@@ -176,6 +178,7 @@ function ImageParagraphWithComments({
   coAuthorUserId,
   isAdmin,
   initialCount,
+  mobileHighlightStyle = "badges",
 }: {
   src: string;
   alt: string;
@@ -185,6 +188,7 @@ function ImageParagraphWithComments({
   coAuthorUserId?: string | null;
   isAdmin: boolean;
   initialCount: number;
+  mobileHighlightStyle?: "badges" | "border";
 }) {
   const isMobile = useContext(IsMobileContext) ?? false;
 
@@ -198,6 +202,7 @@ function ImageParagraphWithComments({
       isMobile={isMobile}
       initialCount={initialCount}
       paragraphProps={{}}
+      mobileHighlightStyle={mobileHighlightStyle}
     >
       <span />
     </LazyParagraphCommentWidget>
@@ -313,6 +318,7 @@ export default function PostContentClient({
               coAuthorUserId={coAuthorUserId}
               isAdmin={isAdmin}
               initialCount={initialCount}
+              mobileHighlightStyle={mobileHighlightStyle}
             />
           );
         }
@@ -336,7 +342,7 @@ export default function PostContentClient({
         element,
         parserOptions,
         currentIndex,
-        { postId, coAuthorUserId, isAdmin },
+        { postId, coAuthorUserId, isAdmin, mobileHighlightStyle },
         summaryMap,
         {
           highlights,

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -38,6 +38,7 @@ export type ParagraphCommentWidgetProps = {
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
   highlightCount?: number;
+  mobileHighlightStyle?: "badges" | "border";
 };
 
 export type ParagraphCommentWidgetComponent =

--- a/src/app/posts/[id]/post-editing-client.tsx
+++ b/src/app/posts/[id]/post-editing-client.tsx
@@ -19,6 +19,7 @@ export type PostEditingClientProps = {
   coAuthorUserId?: string | null;
   coAuthorImageUrl?: string | null;
   paragraphCommentsEnabled: boolean;
+  mobileHighlightStyle: "badges" | "border";
   isAdmin: boolean;
   initialMarkdown: string;
   tags: string[];
@@ -35,6 +36,7 @@ export default function PostEditingClient({
   coAuthorUserId,
   coAuthorImageUrl,
   paragraphCommentsEnabled,
+  mobileHighlightStyle,
   isAdmin,
   initialMarkdown,
   tags,
@@ -189,6 +191,7 @@ export default function PostEditingClient({
           coAuthorUserId={coAuthorUserId}
           coAuthorImageUrl={coAuthorImageUrl}
           paragraphCommentsEnabled={paragraphCommentsEnabled}
+          mobileHighlightStyle={mobileHighlightStyle}
           isAdmin={isAdmin}
           isEditing={false}
         />


### PR DESCRIPTION
### Motivation

- Provide an admin-configurable option to change how paragraph highlights and comments are indicated on mobile, letting the site use either badges or a border affordance.

### Description

- Introduces a persisted `mobileHighlightStyle` setting with a new API at `/admin/api/mobile-highlight-style` (GET/POST) and an admin UI component `MobileHighlightStyleToggle` to switch between `badges` and `border`.
- Reads the setting in the admin analytics page and the post page, and threads `mobileHighlightStyle` down into `PostContentClient`, `PostEditingClient`, paragraph rendering, and `HighlightedParagraph` so the client UI reflects the chosen style.
- Updates `HighlightedParagraph` to apply a left border on mobile when `mobileHighlightStyle === "border"`, and to render a split gradient border when a paragraph both has a highlight and comments; also adds a `hasComments` prop to drive that behavior.

### Testing

- Performed a project type-check/Next.js build (`pnpm build`) to validate server and client code compiled successfully (succeeded).
- Ran linting (`pnpm lint`) and the test suite (`pnpm test`) to ensure no regressions were introduced (all automated checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9d1f8d7808328a7387698a33c74ba)