### PR TITLE
Render left highlight as absolute gradient bar for mobile in HighlightedParagraph

### DIFF
--- a/components/paragraph-comments/HighlightedParagraph.tsx
+++ b/components/paragraph-comments/HighlightedParagraph.tsx
@@ -256,25 +256,27 @@ export default function HighlightedParagraph({
           (paragraphProps as any)?.className,
           "relative",
           mobileHighlightStyle === "border"
-            ? myHighlight && hasComments
-              ? "border-l-2 pl-2"
-              : myHighlight
-                ? "border-l-2 border-yellow-400/60 pl-2"
-                : hasComments
-                  ? "border-l-2 border-purple-400/60 pl-2"
-                  : ""
+            ? (myHighlight || hasComments ? "pl-2" : "")
             : myHighlight
               ? "border-l-2 border-yellow-400/60 pl-2"
               : "",
         ]
           .filter(Boolean)
           .join(" ")}
-        style={
-          mobileHighlightStyle === "border" && myHighlight && hasComments
-            ? { borderImage: "linear-gradient(to bottom, #facc15 50%, #a78bfa 50%) 1" }
-            : undefined
-        }
       >
+        {mobileHighlightStyle === "border" && (myHighlight || hasComments) && (
+          <span
+            aria-hidden
+            className="absolute left-0 top-0 h-full w-0.5"
+            style={{
+              background: myHighlight && hasComments
+                ? "linear-gradient(to bottom, #facc1599 50%, #a78bfa99 50%)"
+                : myHighlight
+                  ? "#facc1599"
+                  : "#a78bfa99",
+            }}
+          />
+        )}
         {children}
       </div>
 


### PR DESCRIPTION
### Motivation
- Replace the CSS `border-left` approach for mobile highlights with a positioned element to allow cleaner gradient rendering and consistent spacing when either a user highlight or comments are present.

### Description
- Remove the conditional `border-l-2` classes and the inline `borderImage` style previously used for the mobile border highlight and keep left padding when a highlight or comments exist.
- Add an absolutely positioned `<span>` (aria-hidden) placed at the left edge to render the highlight bar, using a color or a vertical gradient when both `myHighlight` and `hasComments` are true.
- Preserve existing event handlers and mobile menu behavior while changing only the highlight visual implementation.

### Testing
- Ran unit tests with `yarn test` which completed successfully.
- Ran TypeScript checks with `yarn tsc --noEmit` which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9da7f969483289db4e23055fb9739)