### PR TITLE
Toggle desktop ✦ button between add/remove highlight

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -67,6 +67,8 @@ type ParagraphCommentWidgetProps = {
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
+  onRemoveHighlight?: () => void;
+  hasMyHighlight?: boolean;
   highlightCount?: number;
   mobileHighlightStyle?: "badges" | "border";
 };
@@ -84,6 +86,8 @@ export default function ParagraphCommentWidget({
   autoOpen = false,
   onRegisterOpenComments,
   onHighlight,
+  onRemoveHighlight,
+  hasMyHighlight = false,
   highlightCount = 0,
   mobileHighlightStyle = "badges",
 }: ParagraphCommentWidgetProps) {
@@ -824,12 +828,17 @@ export default function ParagraphCommentWidget({
             >
               <ChatBubbleLeftRightIcon className="h-4 w-4" />
             </button>
-            {onHighlight && (
+            {(onHighlight || onRemoveHighlight) && (
               <button
                 type="button"
-                onClick={onHighlight}
-                className="shrink-0 flex h-8 w-8 items-center justify-center rounded-b-full border border-zinc-300 bg-white text-yellow-500 shadow-sm hover:border-zinc-400 hover:text-yellow-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-yellow-400 dark:hover:border-zinc-500"
-                aria-label="Destacar parágrafo"
+                onClick={hasMyHighlight ? onRemoveHighlight : onHighlight}
+                className={[
+                  "shrink-0 flex h-8 w-8 items-center justify-center rounded-b-full border bg-white shadow-sm focus-visible:outline-none focus-visible:ring-2 dark:bg-zinc-900",
+                  hasMyHighlight
+                    ? "border-red-300 text-red-400 hover:border-red-400 hover:text-red-500 focus-visible:ring-red-500 dark:border-red-800 dark:text-red-400 dark:hover:border-red-600"
+                    : "border-zinc-300 text-yellow-500 hover:border-zinc-400 hover:text-yellow-600 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:text-yellow-400 dark:hover:border-zinc-500",
+                ].join(" ")}
+                aria-label={hasMyHighlight ? "Remover destaque" : "Destacar parágrafo"}
               >
                 ✦
               </button>

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -115,6 +115,22 @@ function renderParagraphWithComments(
                 console.error("Failed to save highlight", error);
               });
           }}
+          hasMyHighlight={highlightProps.highlights.some(
+            (h) => h.paragraphId === paragraphId && h.userId === highlightProps.userId,
+          )}
+          onRemoveHighlight={() => {
+            const mine = highlightProps.highlights.find(
+              (h) => h.paragraphId === paragraphId && h.userId === highlightProps.userId,
+            );
+            if (!mine) return;
+            void fetch(`/api/posts/${encodeURIComponent(options.postId)}/paragraph-highlights`, {
+              method: "DELETE",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ highlightId: mine._id }),
+            })
+              .then(() => highlightProps.onHighlightDeleted(mine._id))
+              .catch(console.error);
+          }}
           highlightCount={highlightProps.highlights.filter((h) => h.paragraphId === paragraphId).length}
           mobileHighlightStyle={highlightProps.mobileHighlightStyle}
         >

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -37,6 +37,8 @@ export type ParagraphCommentWidgetProps = {
   autoOpen?: boolean;
   onRegisterOpenComments?: (fn: () => Promise<void>) => void;
   onHighlight?: () => void;
+  onRemoveHighlight?: () => void;
+  hasMyHighlight?: boolean;
   highlightCount?: number;
   mobileHighlightStyle?: "badges" | "border";
 };


### PR DESCRIPTION
### Motivation
- Make the desktop hover ✦ button toggle between adding and removing a paragraph highlight based on whether the current user already highlighted that paragraph.
- Avoid opening the popover when the user wants to remove their own highlight and make the button reflect the current action with color and `aria-label`.

### Description
- Added `onRemoveHighlight?: () => void` and `hasMyHighlight?: boolean` to `ParagraphCommentWidget` props and defaulted `hasMyHighlight` to `false` in the component signature.
- Replaced the hover desktop ✦ button to render when either `onHighlight` or `onRemoveHighlight` exists and call `hasMyHighlight ? onRemoveHighlight : onHighlight`, switching colors and `aria-label` accordingly.
- Wired `hasMyHighlight` and `onRemoveHighlight` in `src/app/posts/[id]/post-content-client.tsx` so the client can DELETE the user's highlight and notify `onHighlightDeleted`.
- Updated shared `ParagraphCommentWidgetProps` in `post-content-interactive.tsx` to include the new props for type compatibility.

### Testing
- Ran `npm run build`, which failed due to missing environment variables `MONGODB_URI` / `MONGODB_DB` required at build time (environment limitation), so full production build validation could not complete.
- Ran `npx tsc --noEmit`, which failed due to pre-existing TypeScript test errors in `tests/post-reference.test.tsx` unrelated to these changes.
- Started the dev server (`next dev`) successfully and captured a desktop UI screenshot with Playwright to validate the button appearance and behavior visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e30bdcf08328b39de843a252cc8a)