### PR TITLE
Remove character cap for paragraph highlights

### DIFF
--- a/src/app/api/posts/[id]/paragraph-highlights/route.ts
+++ b/src/app/api/posts/[id]/paragraph-highlights/route.ts
@@ -6,7 +6,6 @@ import { getMongoDb } from "@lib/mongo";
 import { resolveAdminStatus } from "@lib/admin";
 
 const COLLECTION = "paragraph-highlights";
-const MAX_LENGTH = 300;
 
 export async function GET(
   _req: Request,
@@ -73,9 +72,9 @@ export async function POST(
     return NextResponse.json({ error: "Dados insuficientes." }, { status: 400 });
   }
 
-  if (selectedText.trim().length === 0 || selectedText.length > MAX_LENGTH) {
+  if (selectedText.trim().length === 0) {
     return NextResponse.json(
-      { error: `Destaque deve ter entre 1 e ${MAX_LENGTH} caracteres.` },
+      { error: "Destaque deve ter pelo menos 1 caractere." },
       { status: 400 }
     );
   }


### PR DESCRIPTION
## Summary
- removed the hard 300-character cap when saving paragraph highlights
- kept validation to reject empty/whitespace-only selections
- updated the API error message to reflect the new rule (minimum of 1 character only)

## Changed file
- `src/app/api/posts/[id]/paragraph-highlights/route.ts`

## Notes
This allows highlighting full paragraphs regardless of length, while still preventing empty highlights.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9edb098808328833ea857221b947d)