### PR TITLE
Narrow middleware matcher to skip Next static assets and common file types

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -77,8 +77,6 @@ export default clerkMiddleware(async (auth, req) => {
 
 export const config = {
   matcher: [
-    // Ignora arquivos estáticos e rotas internas do Next.js
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2|ico|csv|docx?|xlsx?|zip|webmanifest)|public/.*).*)",
-    "/(api/auth|api/clerk)(.*)", // Limite o middleware para rotas de autenticação Clerk
+    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|woff2?|ttf|otf|eot)).*)",
   ],
 };


### PR DESCRIPTION
### Motivation
- Prevent the middleware from running on Next.js static internals and on requests for common static file types to reduce unnecessary middleware execution.

### Description
- Replace the previous matcher entries with a single regex in `export const config.matcher` that excludes `_next/static`, `_next/image`, `favicon.ico`, and common asset extensions while removing the separate auth route matcher and inline comments.

### Testing
- Ran TypeScript type-check with `tsc --noEmit`, `npm run build`, and `npm run lint`, and these automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa084697c88328ad822d9efa5b85d4)