### PR TITLE
Ensure indexes on analytics_events when connecting to MongoDB

### DIFF
--- a/src/lib/mongo.ts
+++ b/src/lib/mongo.ts
@@ -129,13 +129,29 @@ export async function getMongoClient() {
   }
 }
 
+let indexesEnsured = false;
+
+async function ensureIndexes(db: ReturnType<MongoClient["db"]>) {
+  if (indexesEnsured) return;
+  indexesEnsured = true;
+  try {
+    await db.collection("analytics_events").createIndex(
+      { name: 1, "data.postId": 1 },
+      { background: true }
+    );
+  } catch (error) {
+    console.warn("Erro ao criar índices do MongoDB:", error);
+  }
+}
+
 export async function getMongoDb() {
   try {
     const client = await getMongoClient();
-    return client.db(MONGODB_DB);
+    const db = client.db(MONGODB_DB);
+    void ensureIndexes(db);
+    return db;
   } catch (error) {
     console.error("Erro ao acessar o banco de dados MongoDB:", error);
     throw error;
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure required indexes exist for the `analytics_events` collection to improve query performance and avoid missing-index issues on reads that filter by `name` and `data.postId`.

### Description
- Add an `ensureIndexes` function guarded by an `indexesEnsured` flag that creates the index `{ name: 1, "data.postId": 1 }` (with `background: true`) and call it from `getMongoDb` so indexes are created asynchronously on first DB access, with errors logged via `console.warn`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa198d60cc8328ba759fe7334ab059)