### PR TITLE
Refine paragraph comment widget visual weight

### DIFF
--- a/components/paragraph-comments/ParagraphCommentWidget.tsx
+++ b/components/paragraph-comments/ParagraphCommentWidget.tsx
@@ -901,7 +901,7 @@ export default function ParagraphCommentWidget({
         </div>
 
         {isExpanded && (
-          <div className="rounded-xl border border-zinc-200 bg-white p-4 shadow-sm dark:border-zinc-700 dark:bg-zinc-900/70">
+          <div className="rounded-xl border border-zinc-100 bg-white/60 p-4 dark:border-zinc-800 dark:bg-zinc-900/40">
             <div className="flex items-center justify-between pb-3">
               <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-200">
                 Comentários deste parágrafo
@@ -916,7 +916,7 @@ export default function ParagraphCommentWidget({
                 type="button"
                 onClick={() => setIsExpanded(false)}
                 aria-label="Fechar comentários deste parágrafo"
-                className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-zinc-300 text-zinc-500 hover:text-zinc-700 hover:border-zinc-400 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:border-zinc-700 dark:text-zinc-400 dark:hover:text-white dark:hover:border-zinc-500"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-full text-zinc-400 hover:text-zinc-600 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-500 dark:text-zinc-500 dark:hover:text-zinc-300"
               >
                 <XMarkIcon className="h-4 w-4" />
               </button>
@@ -940,7 +940,7 @@ export default function ParagraphCommentWidget({
                 }}
                 placeholder="Escreva seu comentário"
                 rows={3}
-                className="w-full resize-none rounded-lg border border-zinc-300 bg-transparent px-3 py-2 text-sm text-zinc-800 shadow-inner outline-none transition focus:border-zinc-500 focus:ring-2 focus:ring-zinc-200 dark:border-zinc-700 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700 whitespace-pre-wrap break-words"
+                className="w-full resize-none rounded-lg border border-zinc-200 bg-transparent px-3 py-2 text-sm text-zinc-800 outline-none transition focus:border-zinc-400 focus:ring-1 focus:ring-zinc-200 dark:border-zinc-800 dark:text-zinc-100 dark:focus:border-zinc-600 dark:focus:ring-zinc-800 whitespace-pre-wrap break-words"
                 disabled={isFeatureBlocked}
               />
               <div className="flex items-center justify-between text-xs text-zinc-500 dark:text-zinc-400">


### PR DESCRIPTION
### Motivation

- Tornar o painel de comentários do parágrafo mais leve visualmente removendo sombras, reduzindo contraste de bordas e suavizando o fundo para um visual mais elegante.

### Description

- Atualizei o contêiner do bloco `isExpanded` para remover `shadow-sm`, ajustar `border` e usar `bg-white/60` em claro e `dark:bg-zinc-900/40` em escuro.
- Simplifiquei o botão de fechar removendo a borda e afinando a presença visual com tons de texto mais sutis e estilos `hover` menos pronunciados.
- Ajustei o `textarea` removendo `shadow-inner`, reduzindo a intensidade da borda e do `focus` (`ring-1`) e trocando algumas classes de cor para um contraste menor.

### Testing

- Executei `npx tsc --noEmit`, que falhou por erros de tipagem pré-existentes em `tests/post-reference.test.tsx` e não relacionados a estas alterações.
- Iniciei o servidor de desenvolvimento com `npm run dev`, que subiu mas a página inicial retornou 500 por variáveis de ambiente ausentes (`MONGODB_URI` / `MONGODB_DB`), e capturei uma screenshot do estado da interface para validação visual.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad77c3e388328aa6a4f47c587bb3c)