### PR TITLE
Apply attention-heatmap gradient to scroll progress bar with fallback and sizing

### DIFF
--- a/components/HeatmapProgressBar.tsx
+++ b/components/HeatmapProgressBar.tsx
@@ -25,9 +25,14 @@ export default function HeatmapProgressBar({ postId }: { postId: string }) {
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
-        if (!data.available) return;
+        if (!data.available) {
+          document.documentElement.style.setProperty("--scroll-progress-color", "#E00070");
+          document.documentElement.style.setProperty("--scroll-heatmap-visible", "0");
+          return;
+        }
 
         const gradient = buildGradient(data.buckets);
+        document.documentElement.style.setProperty("--scroll-progress-color", gradient);
         document.documentElement.style.setProperty("--scroll-heatmap-gradient", gradient);
         document.documentElement.style.setProperty("--scroll-heatmap-visible", "1");
       })
@@ -35,6 +40,7 @@ export default function HeatmapProgressBar({ postId }: { postId: string }) {
 
     return () => {
       cancelled = true;
+      document.documentElement.style.setProperty("--scroll-progress-color", "#E00070");
       document.documentElement.style.setProperty("--scroll-heatmap-visible", "0");
     };
   }, [postId]);

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -109,7 +109,8 @@ h1 {
   top: calc(env(safe-area-inset-top, 0px));
   left: 0;
   height: 3px;
-  background: #E00070;
+  background: var(--scroll-progress-color, #E00070);
+  background-size: 100vw 100%;
   width: var(--scroll-progress);
   pointer-events: none;
   z-index: 9999;
@@ -135,4 +136,3 @@ h1 {
     transition: none;
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the scroll progress bar reflects the attention heatmap when available and uses a sensible fallback when not available.
- Prevent visual artifacts by sizing the background correctly for gradient usage.

### Description
- Update `HeatmapProgressBar.tsx` to set `--scroll-progress-color` to the heatmap `gradient` when data is available and to the fallback `#E00070` when not available or on cleanup. 
- Preserve the existing heatmap variables by still setting `--scroll-heatmap-gradient` and toggling `--scroll-heatmap-visible` based on availability.
- Update `global.css` to use `var(--scroll-progress-color, #E00070)` for the progress bar background and add `background-size: 100vw 100%` to avoid repeating / sizing issues.

### Testing
- Ran a TypeScript type-check and local build to verify there are no type or compilation errors; checks succeeded.
- Verified the UI behavior locally by loading posts with and without heatmap data to confirm the progress bar uses the gradient when present and falls back to the default color when absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad513d1e48328bf6399d42414570f)