### PR TITLE
Include API routes in middleware matcher and simplify exclusion pattern

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -77,6 +77,7 @@ export default clerkMiddleware(async (auth, req) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|woff2?|ttf|otf|eot)).*)",
+    "/((?!_next/static|_next/image|favicon\\.ico).*)",
+    "/api/(.*)",
   ],
 };


### PR DESCRIPTION
### Motivation
- Ensure the middleware runs for API routes and avoid missing middleware execution for requests under `/api/` by explicitly matching them.

### Description
- Simplified the matcher exclusion to only skip `_next/static`, `_next/image` and `favicon.ico` by replacing the long file-extension blacklist with `"/((?!_next/static|_next/image|favicon\\.ico).*)"`.
- Added an explicit matcher entry for API routes with `"/api/(.*)"` so middleware is applied to API endpoints.
- No other middleware logic or cookie handling was changed.

### Testing
- Ran the project test suite with `npm test` and the linter with `npm run lint`, and both completed successfully.
- Performed a `next build` smoke check and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadba32fd4832894592feb1ccc4f93)