### PR TITLE
Restore original middleware matcher config

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -77,7 +77,7 @@ export default clerkMiddleware(async (auth, req) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon\\.ico).*)",
-    "/api/(.*)",
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2|ico|csv|docx?|xlsx?|zip|webmanifest)|public/.*).*)",
+    "/(api/auth|api/clerk)(.*)",
   ],
 };


### PR DESCRIPTION
### Motivation
- Reverter a alteração do `matcher` em `src/middleware.ts` para restaurar os padrões de roteamento/filtragem originais usados pela aplicação.

### Description
- Atualizei a configuração `export const config.matcher` em `src/middleware.ts` substituindo o padrão anterior por `"/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2|ico|csv|docx?|xlsx?|zip|webmanifest)|public/.*).*)"` para preservar exclusões de `_next` e ativos estáticos.
- Ajustei a segunda entrada do matcher para `"/(api/auth|api/clerk)(.*)"` para limitar a interceptação apenas às rotas de autenticação/clerk.

### Testing
- Executei `git diff -- src/middleware.ts` para validar o diff e confirmei que apenas as duas linhas do `matcher` foram alteradas, e a verificação retornou com as mudanças esperadas.
- Efetuei `git commit -m "Restore original middleware matcher config"` e confirmei que o commit foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaeb53aa8083288d54e35867e34951)