### PR TITLE
Add admin ideas UI, checklist, API routes and types

### DIFF
--- a/src/app/admin/api/ideas/[id]/route.ts
+++ b/src/app/admin/api/ideas/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { getMongoDb } from "@lib/mongo";
+import { resolveAdminStatus } from "@lib/admin";
+import { ObjectId } from "mongodb";
+
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { isAdmin, userId } = await resolveAdminStatus();
+  if (!isAdmin || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const body = await req.json();
+  const db = await getMongoDb();
+  await db.collection("ideas").updateOne(
+    { _id: new ObjectId(id), userId },
+    { $set: body }
+  );
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { isAdmin, userId } = await resolveAdminStatus();
+  if (!isAdmin || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const db = await getMongoDb();
+  await db.collection("ideas").deleteOne({ _id: new ObjectId(id), userId });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/admin/api/ideas/route.ts
+++ b/src/app/admin/api/ideas/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getMongoDb } from "@lib/mongo";
+import { resolveAdminStatus } from "@lib/admin";
+
+export async function GET() {
+  const { isAdmin, userId } = await resolveAdminStatus();
+  if (!isAdmin || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const db = await getMongoDb();
+  const ideas = await db
+    .collection("ideas")
+    .find({ userId })
+    .sort({ createdAt: -1 })
+    .toArray();
+  return NextResponse.json(ideas);
+}
+
+export async function POST(req: Request) {
+  const { isAdmin, userId } = await resolveAdminStatus();
+  if (!isAdmin || !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json();
+  const db = await getMongoDb();
+  const doc = {
+    userId,
+    title: body.title,
+    gatilhoTipo: body.gatilhoTipo,
+    gatilho: body.gatilho,
+    tags: body.tags ?? [],
+    notas: body.notas ?? "",
+    outline: null,
+    outlineAt: null,
+    createdAt: new Date().toISOString(),
+  };
+  const result = await db.collection("ideas").insertOne(doc);
+  return NextResponse.json({ ...doc, _id: result.insertedId }, { status: 201 });
+}

--- a/src/app/admin/checklist/page.tsx
+++ b/src/app/admin/checklist/page.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useState } from "react";
+import type { ChecklistRespostas } from "../../../../types/ideas";
+
+const CRITERIOS = [
+  {
+    id: "gatilho",
+    label: "Gatilho concreto",
+    inegociavel: false,
+    pergunta:
+      "O post parte de algo específico — um comentário, evento, notícia, experiência pessoal?",
+    sim: "Bom. O leitor sabe o que provocou você. Isso ancora o argumento na realidade.",
+    nao: "Post abstrato demais. Considere abrir com o que te fez escrever isso.",
+    parcial:
+      "Tem um gatilho, mas está implícito. Vale torná-lo explícito no primeiro parágrafo.",
+    dica: "Seus melhores posts sempre começam com algo concreto.",
+  },
+  {
+    id: "tese",
+    label: "Tese em uma frase",
+    inegociavel: false,
+    pergunta:
+      "Você consegue resumir a posição central do post em uma única frase direta?",
+    sim: "Ótimo. Clareza de tese é clareza de argumento.",
+    nao: "Se você não consegue resumir, o leitor também não vai conseguir. O post precisa de mais foco.",
+    parcial: "A tese existe mas está difusa. Tente explicitá-la.",
+    dica: "Uma frase. Sem subteses.",
+  },
+  {
+    id: "contraponto",
+    label: "Contraponto honesto",
+    inegociavel: true,
+    pergunta:
+      "O argumento oposto foi apresentado de forma honesta — não como palha fácil — antes de ser refutado?",
+    sim: "Excelente. Destruir o argumento real é muito mais convincente do que destruir espantalho.",
+    nao: "Você está pregando para convertidos. Quem discorda vai achar que você não entendeu a posição dele.",
+    parcial:
+      "O contraponto aparece, mas está enfraquecido. Fortaleça-o antes de refutar.",
+    dica: "A regra: o oponente precisaria reconhecer sua própria posição no que você descreve.",
+  },
+  {
+    id: "evidencia",
+    label: "Evidência histórica ou concreta",
+    inegociavel: true,
+    pergunta:
+      "O argumento é sustentado por pelo menos um exemplo histórico, dado concreto ou caso real?",
+    sim: "Bem. Argumento sem evidência é opinião. Com evidência, vira posição defensável.",
+    nao: "Você está pedindo que o leitor confie na sua lógica sem verificar.",
+    parcial:
+      "Tem evidência, mas vaga. 'Países que adotaram o livre mercado cresceram' não é evidência — Chile em 1975 é.",
+    dica: "Especificidade vence generalidade. Use nomes e datas.",
+  },
+  {
+    id: "principio",
+    label: "Conexão com princípio liberal",
+    inegociavel: true,
+    pergunta:
+      "O post se conecta explicitamente a um princípio — propriedade, liberdade individual, limite do Estado, due process?",
+    sim: "Bom. Você não está só comentando um evento — está mostrando o que ele revela sobre algo maior.",
+    nao: "O post corre o risco de parecer reativo. Sem princípio explícito, parece que você é contra isso, não a favor de algo.",
+    parcial: "O princípio está subentendido. Vale uma frase que o deixe claro.",
+    dica: "Seu diferencial é conectar o concreto ao teórico. Não abra mão disso.",
+  },
+  {
+    id: "falseavel",
+    label: "Argumento falsificável",
+    inegociavel: true,
+    pergunta:
+      "Sua conclusão poderia ser provada errada se um dado ou exemplo contrário aparecesse?",
+    sim: "Ótimo. Argumento falsificável é argumento honesto.",
+    nao: "Cuidado. Se nada pode provar que você está errado, você não está fazendo um argumento — está fazendo uma crença.",
+    parcial:
+      "A conclusão é parcialmente falsificável. Tente torná-la mais específica.",
+    dica: "Ex ruim: 'O Estado sempre atrapalha.' Ex bom: 'Em economias com índice de liberdade acima de 7, o crescimento foi maior.'",
+  },
+  {
+    id: "provocacao",
+    label: "Provocação final",
+    inegociavel: false,
+    pergunta:
+      "O post fecha com algo que o leitor não consegue ignorar — uma pergunta, uma implicação incômoda, uma inversão?",
+    sim: "Perfeito. É o que faz o leitor compartilhar.",
+    nao: "O post termina antes de acabar. Considere fechar com uma pergunta que o leitor vai carregar.",
+    parcial:
+      "Tem um fechamento, mas é conclusivo demais. Uma boa provocação deixa espaço para o leitor pensar.",
+    dica: "Uma pergunta que o leitor vai carregar.",
+  },
+  {
+    id: "audiencia",
+    label: "Clareza de audiência",
+    inegociavel: false,
+    pergunta:
+      "Você sabe para quem está escrevendo — iniciante no tema, já convencido, ou adversário ideológico?",
+    sim: "Bem. Post que tenta falar com todo mundo não fala com ninguém.",
+    nao: "Defina antes de publicar. Tom, profundidade e exemplos mudam completamente.",
+    parcial:
+      "Você tem uma audiência em mente, mas o texto oscila entre níveis. Escolha um.",
+    dica: "Você não precisa sempre escrever para convertidos. Mas precisa saber quando está fazendo isso.",
+  },
+] as const;
+
+type Resposta = "sim" | "parcial" | "não";
+type Phase = "intro" | "checklist" | "result";
+
+function calcularNota(respostas: Partial<ChecklistRespostas>) {
+  let total = 0;
+  let max = 0;
+  CRITERIOS.forEach((c) => {
+    const peso = c.inegociavel ? 3 : 1;
+    max += peso * 2;
+    const r = respostas[c.id as keyof ChecklistRespostas];
+    if (r === "sim") total += peso * 2;
+    if (r === "parcial") total += peso;
+  });
+  return Math.round((total / max) * 100);
+}
+
+function getVeredicto(nota: number, respostas: Partial<ChecklistRespostas>) {
+  const falhouInegociavel = CRITERIOS.filter((c) => c.inegociavel).some(
+    (c) => respostas[c.id as keyof ChecklistRespostas] === "não"
+  );
+  if (falhouInegociavel) return "Não está pronto";
+  if (nota >= 85) return "Pronto para publicar";
+  if (nota >= 65) return "Quase lá";
+  return "Precisa de trabalho";
+}
+
+function getVeredictoColor(v: string) {
+  if (v === "Pronto para publicar") return "#5a9e5a";
+  if (v === "Quase lá") return "#E00070";
+  return "#c86e6e";
+}
+
+export default function ChecklistPage() {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [postTitulo, setPostTitulo] = useState("");
+  const [step, setStep] = useState(0);
+  const [respostas, setRespostas] = useState<Partial<ChecklistRespostas>>({});
+
+  const criterioAtual = CRITERIOS[step];
+  const nota = calcularNota(respostas);
+  const veredicto = getVeredicto(nota, respostas);
+  const veredictoColor = getVeredictoColor(veredicto);
+
+  function handleResposta(r: Resposta) {
+    const novasRespostas = { ...respostas, [criterioAtual.id]: r };
+    setRespostas(novasRespostas);
+    if (step < CRITERIOS.length - 1) {
+      setStep((p) => p + 1);
+    } else {
+      setPhase("result");
+    }
+  }
+
+  function reiniciar() {
+    setPhase("intro");
+    setStep(0);
+    setRespostas({});
+    setPostTitulo("");
+  }
+
+  return (
+    <div className="mx-auto min-h-screen max-w-2xl bg-[#040404] p-6 text-[#f1f1f1]">
+      {phase === "intro" && (
+        <div className="flex flex-col gap-6">
+          <h1 className="text-2xl font-bold">Checklist Pré-Publicação</h1>
+          <p className="text-sm text-[#A8A095]">
+            8 critérios. Responda um por vez. O post ou está pronto ou não está.
+          </p>
+
+          <div className="rounded-md border border-white/10 bg-zinc-900/50 p-4">
+            <p className="mb-3 text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+              Critérios inegociáveis
+            </p>
+            <div className="flex flex-col gap-1.5">
+              {CRITERIOS.filter((c) => c.inegociavel).map((c) => (
+                <div key={c.id} className="flex items-center gap-2 text-sm">
+                  <span className="text-[#E00070]">⚑</span>
+                  <span>{c.label}</span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-xs text-[#A8A095]">
+              Falhar em qualquer um desses bloqueia a publicação independente da nota.
+            </p>
+          </div>
+
+          <input
+            value={postTitulo}
+            onChange={(e) => setPostTitulo(e.target.value)}
+            placeholder="Título do post (opcional)"
+            className="rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+          />
+
+          <button
+            onClick={() => setPhase("checklist")}
+            className="rounded-md bg-[#E00070] py-2.5 text-sm font-bold text-white transition hover:opacity-80"
+          >
+            Iniciar checklist
+          </button>
+        </div>
+      )}
+
+      {phase === "checklist" && (
+        <div className="flex flex-col gap-5">
+          <div className="fixed left-0 right-0 top-0 z-50 h-0.5 bg-zinc-800">
+            <div
+              className="h-full bg-[#E00070] transition-all duration-300"
+              style={{ width: `${((step + 1) / CRITERIOS.length) * 100}%` }}
+            />
+          </div>
+
+          <div className="mt-2 flex items-center gap-2">
+            <span className="text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+              {step + 1} / {CRITERIOS.length}
+            </span>
+            {criterioAtual.inegociavel && (
+              <span className="rounded border border-[#E00070]/40 px-2 py-0.5 text-[10px] font-bold text-[#E00070]">
+                ⚑ inegociável
+              </span>
+            )}
+          </div>
+
+          <h2 className="text-xl font-bold">{criterioAtual.label}</h2>
+          <p className="text-base text-[#f1f1f1]">{criterioAtual.pergunta}</p>
+
+          <div className="rounded-r-md border-l-2 border-[#E00070] bg-zinc-900/50 py-2 pl-3 pr-3">
+            <p className="text-xs text-[#A8A095]">{criterioAtual.dica}</p>
+          </div>
+
+          <div className="mt-2 flex flex-col gap-2">
+            <button
+              onClick={() => handleResposta("sim")}
+              className="flex items-center gap-3 rounded-md border border-white/10 px-4 py-3 text-left transition hover:border-[#5a9e5a] hover:bg-[#5a9e5a]/5"
+            >
+              <span className="text-sm font-bold text-[#5a9e5a]">✓ Sim</span>
+            </button>
+            <button
+              onClick={() => handleResposta("parcial")}
+              className="flex items-center gap-3 rounded-md border border-white/10 px-4 py-3 text-left transition hover:border-[#E00070]/50 hover:bg-[#E00070]/5"
+            >
+              <span className="text-sm font-bold text-[#E00070]">~ Parcialmente</span>
+            </button>
+            <button
+              onClick={() => handleResposta("não")}
+              className="flex items-center gap-3 rounded-md border border-white/10 px-4 py-3 text-left transition hover:border-[#c86e6e]/50 hover:bg-[#c86e6e]/5"
+            >
+              <span className="text-sm font-bold text-[#c86e6e]">✕ Não</span>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {phase === "result" && (
+        <div className="flex flex-col gap-6">
+          {postTitulo && <p className="text-sm text-[#A8A095]">"{postTitulo}"</p>}
+
+          <div className="flex flex-col gap-2">
+            <span style={{ color: veredictoColor }} className="text-6xl font-bold">
+              {nota}
+            </span>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-800">
+              <div
+                className="h-full rounded-full transition-all duration-700"
+                style={{ width: `${nota}%`, backgroundColor: veredictoColor }}
+              />
+            </div>
+            <div
+              className="mt-1 rounded-md border px-4 py-3"
+              style={{
+                borderColor: `${veredictoColor}40`,
+                backgroundColor: `${veredictoColor}10`,
+              }}
+            >
+              <p className="text-sm font-bold" style={{ color: veredictoColor }}>
+                {veredicto}
+              </p>
+              {veredicto === "Não está pronto" && (
+                <p className="mt-1 text-xs text-[#A8A095]">
+                  Falhou em critério inegociável. Corrija antes de publicar.
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+              Diagnóstico
+            </p>
+            {CRITERIOS.map((c) => {
+              const r = respostas[c.id as keyof ChecklistRespostas];
+              const feedback = r ? c[r as "sim" | "parcial" | "nao"] : "";
+              const color = r === "sim" ? "#5a9e5a" : r === "parcial" ? "#E00070" : "#c86e6e";
+              const icon = r === "sim" ? "✓" : r === "parcial" ? "~" : "✕";
+              return (
+                <div
+                  key={c.id}
+                  className="flex flex-col gap-1 rounded-md border border-white/10 px-3 py-2.5"
+                >
+                  <div className="flex items-center gap-2">
+                    <span style={{ color }} className="text-xs font-bold">
+                      {icon}
+                    </span>
+                    <span className="text-sm font-medium">{c.label}</span>
+                    {c.inegociavel && <span className="text-[10px] text-[#E00070]">⚑</span>}
+                    <span className="ml-auto text-[10px] text-[#A8A095]">{r}</span>
+                  </div>
+                  {feedback && <p className="text-xs italic text-[#A8A095]">{feedback}</p>}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="border-l-2 border-[#E00070] py-2 pl-4">
+            {veredicto === "Pronto para publicar" ? (
+              <p className="text-sm text-[#f1f1f1]">
+                O post está sólido. Todos os critérios passaram. Pode publicar.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <p className="text-sm font-bold text-[#f1f1f1]">Antes de publicar, corrija:</p>
+                {CRITERIOS.filter(
+                  (c) => respostas[c.id as keyof ChecklistRespostas] !== "sim"
+                ).map((c) => {
+                  const r = respostas[c.id as keyof ChecklistRespostas];
+                  if (!r) return null;
+                  return (
+                    <div key={c.id} className="text-sm text-[#A8A095]">
+                      <span className="font-medium text-[#f1f1f1]">{c.label}: </span>
+                      {c[r as "parcial" | "nao"]} {c.dica}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <button
+            onClick={reiniciar}
+            className="rounded-md border border-white/10 py-2.5 text-sm text-[#A8A095] transition hover:border-white/30"
+          >
+            Novo checklist
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/ideias/page.tsx
+++ b/src/app/admin/ideias/page.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Idea, IdeaOutline } from "../../../../types/ideas";
+
+const GATILHOS = [
+  "Comentário / debate online",
+  "Notícia ou evento político",
+  "Experiência pessoal",
+  "Morte / atentado",
+  "Lançamento de produto / tecnologia",
+  "Lei ou medida governamental",
+  "Outro",
+];
+
+const TAGS_SUGERIDAS = [
+  "liberalismo",
+  "liberdade-economia",
+  "desigualdade",
+  "STF",
+  "censura",
+  "intervenção-estado",
+  "justiça-social",
+  "propriedade-privada",
+  "IA",
+  "regulamentação",
+  "história",
+  "política",
+  "direitos-individuais",
+];
+
+const OUTLINE_STEPS = [
+  {
+    id: "gatilho",
+    label: "Gatilho",
+    icon: "⚡",
+    description: "O que provocou esse post? Seja específico.",
+    placeholder: "Ex: Um comentário no Instagram sobre impostos progressivos...",
+    tip: "Seus melhores posts sempre começam com algo concreto que te irritou, emocionou ou intrigou.",
+  },
+  {
+    id: "tese",
+    label: "Tese central",
+    icon: "🎯",
+    description: "Em uma frase, qual é sua posição?",
+    placeholder:
+      "Ex: A desigualdade no Brasil é produto do Estado, não do livre mercado.",
+    tip: "Se não der pra resumir em uma frase, a ideia ainda não está madura.",
+  },
+  {
+    id: "argumento_principal",
+    label: "Argumento principal",
+    icon: "🔑",
+    description: "Por que sua tese é verdadeira? O mecanismo central.",
+    placeholder:
+      "Ex: Toda intervenção estatal cria privilégios para poucos às custas de todos...",
+    tip: "Aqui entra Bastiat, Hayek, exemplos históricos. O coração analítico do post.",
+  },
+  {
+    id: "historico",
+    label: "Contexto histórico",
+    icon: "📜",
+    description: "Qual exemplo histórico ou caso concreto sustenta seu argumento?",
+    placeholder:
+      "Ex: Capitanias hereditárias, Navigation Acts, Homestead Act...",
+    tip: "Especificidade vence generalidade. Use nomes e datas.",
+  },
+  {
+    id: "contraponto",
+    label: "O que os outros dizem",
+    icon: "⚖️",
+    description: "Qual é o argumento oposto mais forte? Como você responde?",
+    placeholder:
+      "Ex: 'Impostos progressivos são justiça social' — mas redistribuição não ataca a raiz...",
+    tip: "Seus posts ficam mais fortes quando você trata o argumento contrário de forma honesta antes de destruí-lo.",
+  },
+  {
+    id: "implicacao",
+    label: "Implicação prática",
+    icon: "🔧",
+    description: "O que muda se sua tese for aceita?",
+    placeholder: "Ex: Flat tax, vouchers, limite ao poder do STF...",
+    tip: "Você não fica no abstrato — sempre conecta ao concreto. Mantenha isso.",
+  },
+  {
+    id: "provocacao",
+    label: "Provocação final",
+    icon: "💥",
+    description: "Com qual pergunta ou frase você fecha o post?",
+    placeholder:
+      "Ex: Se a desigualdade foi moldada pelo Estado, suas ideias de redistribuição desafiam o sistema ou apenas o reforçam?",
+    tip: "Sua melhor assinatura. Uma pergunta que o leitor não consegue ignorar.",
+  },
+] as const;
+
+type View = "list" | "new" | "outline";
+
+export default function IdeiasPage() {
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [view, setView] = useState<View>("list");
+  const [selectedIdea, setSelectedIdea] = useState<Idea | null>(null);
+  const [outlineStep, setOutlineStep] = useState(0);
+  const [outlineData, setOutlineData] = useState<Partial<IdeaOutline>>({});
+  const [toast, setToast] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [gatilhoTipo, setGatilhoTipo] = useState("");
+  const [gatilho, setGatilho] = useState("");
+  const [tags, setTags] = useState<string[]>([]);
+  const [notas, setNotas] = useState("");
+  const [customTag, setCustomTag] = useState("");
+
+  useEffect(() => {
+    void fetchIdeas();
+  }, []);
+
+  async function fetchIdeas() {
+    setLoading(true);
+    const res = await fetch("/admin/api/ideas");
+    const data = await res.json();
+    setIdeas(Array.isArray(data) ? data : []);
+    setLoading(false);
+  }
+
+  function showToast(msg: string) {
+    setToast(msg);
+    setTimeout(() => setToast(null), 2500);
+  }
+
+  async function handleCreateIdea() {
+    if (!title.trim() || !gatilhoTipo) return;
+    await fetch("/admin/api/ideas", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title, gatilhoTipo, gatilho, tags, notas }),
+    });
+    showToast("Ideia salva.");
+    setTitle("");
+    setGatilhoTipo("");
+    setGatilho("");
+    setTags([]);
+    setNotas("");
+    setView("list");
+    void fetchIdeas();
+  }
+
+  async function handleDeleteIdea(id: string) {
+    await fetch(`/admin/api/ideas/${id}`, { method: "DELETE" });
+    showToast("Ideia removida.");
+    void fetchIdeas();
+  }
+
+  function openOutline(idea: Idea) {
+    setSelectedIdea(idea);
+    setOutlineData(idea.outline ?? {});
+    setOutlineStep(0);
+    setView("outline");
+  }
+
+  async function handleSaveOutline() {
+    if (!selectedIdea) return;
+    await fetch(`/admin/api/ideas/${selectedIdea._id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        outline: outlineData,
+        outlineAt: new Date().toISOString(),
+      }),
+    });
+    showToast("Outline salvo.");
+    setView("list");
+    void fetchIdeas();
+  }
+
+  const currentStep = OUTLINE_STEPS[outlineStep];
+
+  return (
+    <div className="mx-auto min-h-screen max-w-4xl bg-[#040404] p-6 text-[#f1f1f1]">
+      {toast && (
+        <div className="fixed bottom-6 right-6 z-50 rounded-md bg-[#E00070] px-4 py-2 text-xs font-bold text-white">
+          {toast}
+        </div>
+      )}
+
+      {view === "list" && (
+        <>
+          <div className="mb-8 flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-[#f1f1f1]">Banco de Ideias</h1>
+            <button
+              onClick={() => setView("new")}
+              className="rounded-md bg-[#E00070] px-4 py-2 text-sm font-bold text-white transition hover:opacity-80"
+            >
+              + Nova Ideia
+            </button>
+          </div>
+
+          {loading ? (
+            <p className="text-sm text-[#A8A095]">Carregando...</p>
+          ) : ideas.length === 0 ? (
+            <p className="text-sm text-[#A8A095]">Nenhuma ideia ainda.</p>
+          ) : (
+            <div className="grid gap-3">
+              {ideas.map((idea) => (
+                <div
+                  key={idea._id}
+                  className="flex flex-col gap-2 rounded-md border border-white/10 bg-zinc-900/50 p-4"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex flex-col gap-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded border border-white/10 bg-zinc-800 px-2 py-0.5 text-[10px] font-bold text-[#A8A095]">
+                          {idea.gatilhoTipo}
+                        </span>
+                        {idea.outline && (
+                          <span className="rounded border border-[#E00070]/40 bg-[#E00070]/20 px-2 py-0.5 text-[10px] font-bold text-[#E00070]">
+                            outline ✓
+                          </span>
+                        )}
+                      </div>
+                      <h2 className="font-bold text-[#f1f1f1]">{idea.title}</h2>
+                      {idea.gatilho && (
+                        <p className="line-clamp-2 text-sm text-[#A8A095]">{idea.gatilho}</p>
+                      )}
+                      {idea.tags.length > 0 && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {idea.tags.map((t) => (
+                            <span
+                              key={t}
+                              className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-[#A8A095]"
+                            >
+                              {t}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 flex flex-col gap-2">
+                      <button
+                        onClick={() => openOutline(idea)}
+                        className="whitespace-nowrap rounded border border-white/10 px-3 py-1.5 text-xs text-[#f1f1f1] transition hover:border-[#E00070]/50"
+                      >
+                        {idea.outline ? "Ver Outline" : "Criar Outline →"}
+                      </button>
+                      <button
+                        onClick={() => handleDeleteIdea(idea._id)}
+                        className="text-right text-xs text-[#A8A095] transition hover:text-red-400"
+                      >
+                        remover
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {view === "new" && (
+        <>
+          <div className="mb-8 flex items-center gap-4">
+            <button
+              onClick={() => setView("list")}
+              className="text-sm text-[#A8A095] transition hover:text-[#f1f1f1]"
+            >
+              ← Voltar
+            </button>
+            <h1 className="text-2xl font-bold">Nova Ideia</h1>
+          </div>
+
+          <div className="flex flex-col gap-5">
+            <div>
+              <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                Título
+              </label>
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="O que você quer dizer?"
+                className="w-full rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                Tipo de gatilho
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {GATILHOS.map((g) => (
+                  <button
+                    key={g}
+                    onClick={() => setGatilhoTipo(g)}
+                    className={`rounded border px-3 py-1.5 text-xs transition ${
+                      gatilhoTipo === g
+                        ? "border-[#E00070] bg-[#E00070] text-white"
+                        : "border-white/10 text-[#A8A095] hover:border-white/30"
+                    }`}
+                  >
+                    {g}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                O que aconteceu?
+              </label>
+              <textarea
+                value={gatilho}
+                onChange={(e) => setGatilho(e.target.value)}
+                rows={3}
+                placeholder="Descreva o gatilho sem compromisso com a tese..."
+                className="w-full resize-none rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                Tags
+              </label>
+              <div className="mb-2 flex flex-wrap gap-2">
+                {TAGS_SUGERIDAS.map((t) => (
+                  <button
+                    key={t}
+                    onClick={() =>
+                      setTags((prev) =>
+                        prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]
+                      )
+                    }
+                    className={`rounded border px-2 py-1 text-xs transition ${
+                      tags.includes(t)
+                        ? "border-[#E00070]/50 bg-[#E00070]/20 text-[#f1f1f1]"
+                        : "border-white/10 text-[#A8A095] hover:border-white/30"
+                    }`}
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
+              <input
+                value={customTag}
+                onChange={(e) => setCustomTag(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && customTag.trim()) {
+                    setTags((prev) => [...prev, customTag.trim()]);
+                    setCustomTag("");
+                  }
+                }}
+                placeholder="Tag personalizada (Enter para adicionar)"
+                className="w-full rounded-md border border-white/10 bg-zinc-900 px-3 py-1.5 text-xs text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                Notas livres
+              </label>
+              <textarea
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                rows={3}
+                placeholder="Referências, links, pensamentos soltos..."
+                className="w-full resize-none rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+              />
+            </div>
+
+            <button
+              onClick={handleCreateIdea}
+              disabled={!title.trim() || !gatilhoTipo}
+              className="rounded-md bg-[#E00070] py-2.5 text-sm font-bold text-white transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-30"
+            >
+              Salvar Ideia
+            </button>
+          </div>
+        </>
+      )}
+
+      {view === "outline" && selectedIdea && (
+        <>
+          <div className="mb-6 flex items-center gap-4">
+            <button
+              onClick={() => setView("list")}
+              className="text-sm text-[#A8A095] transition hover:text-[#f1f1f1]"
+            >
+              ← Voltar
+            </button>
+            <h1 className="truncate text-lg font-bold">{selectedIdea.title}</h1>
+          </div>
+
+          <div className="mb-8 flex items-center gap-2">
+            {OUTLINE_STEPS.map((s, i) => {
+              const hasContent = !!(outlineData as Record<string, string>)[s.id];
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => setOutlineStep(i)}
+                  className={`h-2 rounded-full transition-all ${
+                    i === outlineStep
+                      ? "w-6 bg-[#E00070]"
+                      : hasContent
+                        ? "w-2 bg-[#3a5a3a]"
+                        : "w-2 bg-zinc-700"
+                  }`}
+                />
+              );
+            })}
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-2xl">{currentStep.icon}</span>
+              <span className="text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                Passo {outlineStep + 1} de {OUTLINE_STEPS.length}
+              </span>
+            </div>
+            <h2 className="text-xl font-bold">{currentStep.label}</h2>
+            <p className="text-sm text-[#A8A095]">{currentStep.description}</p>
+
+            <div className="rounded-r-md border-l-2 border-[#E00070] bg-zinc-900/50 py-2 pl-3 pr-3">
+              <p className="text-xs text-[#A8A095]">{currentStep.tip}</p>
+            </div>
+
+            <textarea
+              rows={5}
+              value={(outlineData as Record<string, string>)[currentStep.id] ?? ""}
+              onChange={(e) =>
+                setOutlineData((prev) => ({ ...prev, [currentStep.id]: e.target.value }))
+              }
+              placeholder={currentStep.placeholder}
+              className="w-full resize-none rounded-md border border-white/10 bg-zinc-900 px-3 py-2 text-sm text-[#f1f1f1] placeholder:text-zinc-600 focus:border-[#E00070]/50 focus:outline-none"
+            />
+
+            <div className="flex gap-3">
+              {outlineStep > 0 && (
+                <button
+                  onClick={() => setOutlineStep((p) => p - 1)}
+                  className="flex-1 rounded-md border border-white/10 py-2 text-sm text-[#A8A095] transition hover:border-white/30"
+                >
+                  ← Anterior
+                </button>
+              )}
+              {outlineStep < OUTLINE_STEPS.length - 1 ? (
+                <button
+                  onClick={() => setOutlineStep((p) => p + 1)}
+                  className="flex-1 rounded-md bg-zinc-800 py-2 text-sm font-bold text-[#f1f1f1] transition hover:bg-zinc-700"
+                >
+                  Próximo →
+                </button>
+              ) : (
+                <button
+                  onClick={handleSaveOutline}
+                  className="flex-1 rounded-md bg-[#E00070] py-2 text-sm font-bold text-white transition hover:opacity-80"
+                >
+                  Salvar Outline
+                </button>
+              )}
+            </div>
+
+            {Object.values(outlineData).some(Boolean) && (
+              <details className="mt-4 rounded-md border border-white/10">
+                <summary className="cursor-pointer px-4 py-3 text-xs font-bold uppercase tracking-widest text-[#A8A095]">
+                  Preview do outline
+                </summary>
+                <div className="flex flex-col gap-3 px-4 pb-4">
+                  {OUTLINE_STEPS.map((s) => {
+                    const val = (outlineData as Record<string, string>)[s.id];
+                    if (!val) return null;
+                    return (
+                      <div key={s.id}>
+                        <p className="mb-1 text-[10px] font-bold uppercase tracking-widest text-[#A8A095]">
+                          {s.icon} {s.label}
+                        </p>
+                        <p className="text-sm text-[#f1f1f1]">{val}</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </details>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/types/ideas.ts
+++ b/types/ideas.ts
@@ -1,0 +1,33 @@
+export type IdeaOutline = {
+  gatilho: string;
+  tese: string;
+  argumento_principal: string;
+  historico: string;
+  contraponto: string;
+  implicacao: string;
+  provocacao: string;
+};
+
+export type Idea = {
+  _id: string;
+  userId: string;
+  title: string;
+  gatilhoTipo: string;
+  gatilho: string;
+  tags: string[];
+  notas: string;
+  outline: IdeaOutline | null;
+  outlineAt: string | null;
+  createdAt: string;
+};
+
+export type ChecklistRespostas = {
+  gatilho: "sim" | "parcial" | "não";
+  tese: "sim" | "parcial" | "não";
+  contraponto: "sim" | "parcial" | "não";
+  evidencia: "sim" | "parcial" | "não";
+  principio: "sim" | "parcial" | "não";
+  falseavel: "sim" | "parcial" | "não";
+  provocacao: "sim" | "parcial" | "não";
+  audiencia: "sim" | "parcial" | "não";
+};


### PR DESCRIPTION
### Motivation

- Provide an admin-only idea bank with the ability to create, list, delete and build outlines for ideas.
- Add a pre-publication checklist UI to assess posts against a set of editorial criteria.
- Secure idea management endpoints behind admin authentication and persist data to MongoDB.

### Description

- Add REST API handlers `GET`/`POST` in `src/app/admin/api/ideas/route.ts` and `PUT`/`DELETE` in `src/app/admin/api/ideas/[id]/route.ts` that use `resolveAdminStatus`, `getMongoDb` and `ObjectId` to enforce admin access and operate on the `ideas` collection.
- Implement the idea management UI in `src/app/admin/ideias/page.tsx` as a client React component that supports listing, creating, deleting ideas, and an outline editor that saves `outline` and `outlineAt` via the API.
- Implement the pre-publication checklist UI in `src/app/admin/checklist/page.tsx` as a client React component that guides through criteria, computes a score, and shows diagnostic feedback and a publish veredict.
- Add type definitions in `types/ideas.ts` for `Idea`, `IdeaOutline` and `ChecklistRespostas` to centralize shapes used by the UI and API.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1f779e788328959c7816bd9dc6ae)