### PR TITLE
Revamp admin layout: sidebar with icons, mobile menu toggle, and styling refresh

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,148 +4,178 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ReactNode, useState } from "react";
 import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
+import {
+  Squares2X2Icon,
+  UsersIcon,
+  PencilSquareIcon,
+  ChartBarIcon,
+  LightBulbIcon,
+  ClipboardDocumentCheckIcon,
+  Bars3Icon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 
 const navItems = [
-  { href: "/admin", label: "Dashboard" },
-  { href: "/admin/users", label: "Usuários" },
-  { href: "/admin/editor", label: "Novo post" },
-  { href: "/admin/analytics", label: "Analytics" },
+  { href: "/admin", label: "Dashboard", icon: Squares2X2Icon },
+  { href: "/admin/editor", label: "Novo post", icon: PencilSquareIcon },
+  { href: "/admin/analytics", label: "Analytics", icon: ChartBarIcon },
+  { href: "/admin/users", label: "Usuários", icon: UsersIcon },
+  { href: "/admin/ideias", label: "Banco de Ideias", icon: LightBulbIcon },
+  { href: "/admin/checklist", label: "Checklist", icon: ClipboardDocumentCheckIcon },
 ];
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
 
+  const SidebarContent = () => (
+    <>
+      <div className="px-5 py-5 border-b border-white/8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-3 rounded-lg px-2 py-1.5 text-sm font-semibold tracking-tight text-[#f1f1f1] transition-colors hover:bg-white/5"
+        >
+          <span className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-white/10 bg-white/5 text-xs font-bold text-[#f1f1f1]">
+            d
+          </span>
+          domenyk.com
+        </Link>
+      </div>
+
+      <nav className="flex-1 px-4 py-6">
+        <p className="mb-3 px-3 text-[10px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
+          Painel
+        </p>
+        <ul className="space-y-1 list-none p-0 m-0">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            const Icon = item.icon;
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  onClick={() => setMobileOpen(false)}
+                  className={`group flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all ${
+                    isActive
+                      ? "bg-[#E00070]/10 text-[#f1f1f1] border border-[#E00070]/25"
+                      : "border border-transparent text-[#A8A095] hover:bg-white/5 hover:text-[#f1f1f1]"
+                  }`}
+                >
+                  <Icon
+                    className={`h-4 w-4 shrink-0 transition-colors ${
+                      isActive ? "text-[#E00070]" : "text-[#A8A095] group-hover:text-[#f1f1f1]"
+                    }`}
+                  />
+                  <span>{item.label}</span>
+                  {isActive && (
+                    <span className="ml-auto h-1.5 w-1.5 rounded-full bg-[#E00070]" />
+                  )}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="p-4 border-t border-white/8 mt-auto">
+        <SignedIn>
+          <div className="flex items-center justify-between rounded-lg border border-white/8 bg-white/5 px-4 py-3">
+            <span className="text-xs text-[#A8A095]">Logado</span>
+            <UserButton appearance={{ elements: { userButtonPopoverCard: "bg-zinc-900" } }} />
+          </div>
+        </SignedIn>
+        <SignedOut>
+          <SignInButton>
+            <button className="w-full rounded-md bg-[#E00070] px-4 py-3 text-sm font-medium text-white hover:opacity-80 transition">
+              Entrar
+            </button>
+          </SignInButton>
+        </SignedOut>
+      </div>
+    </>
+  );
+
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 overflow-x-hidden">
+    <div className="min-h-screen bg-[#040404] text-[#f1f1f1] overflow-x-hidden">
       <div className="grid min-h-screen grid-cols-1 md:grid-cols-[220px_1fr]">
-        <aside className="hidden md:flex md:flex-col border-r border-zinc-800/80 bg-gradient-to-b from-zinc-900 via-zinc-950 to-black shadow-[inset_-1px_0_0_rgba(63,63,70,0.4)]">
-          <div className="px-5 py-5 border-b border-zinc-800/80">
-            <Link
-              href="/"
-              className="inline-flex items-center gap-3 rounded-lg px-2 py-1.5 text-base font-semibold tracking-tight text-zinc-100 transition-colors hover:bg-zinc-800/60"
-            >
-              <span className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 text-xs font-bold text-zinc-300">
-                d
-              </span>
-              domenyk.com
-            </Link>
-          </div>
-          <nav className="flex-1 px-4 py-6">
-            <p className="mb-3 px-3 text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">
-              Painel
-            </p>
-            <ul className="space-y-1.5 bg-transparent list-none p-0 m-0">
-              {navItems.map((item) => {
-                const isActive = pathname === item.href;
-                return (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className={`group flex items-center justify-between rounded-lg border px-3 py-2.5 text-sm font-medium transition-all ${isActive
-                          ? "border-zinc-700 bg-zinc-800/90 text-zinc-100 shadow-sm"
-                          : "border-transparent text-zinc-400 hover:border-zinc-800 hover:bg-zinc-900 hover:text-zinc-200"
-                        }`}
-                    >
-                      <span>{item.label}</span>
-                      <span className={`text-xs transition-opacity ${isActive ? "opacity-100 text-zinc-500" : "opacity-0 group-hover:opacity-100 text-zinc-600"}`}>
-                        →
-                      </span>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </nav>
-          <div className="p-4 border-t border-zinc-800/80 mt-auto">
-            <SignedIn>
-              <div className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900/90 px-4 py-3">
-                <span className="text-xs text-zinc-400">Logado</span>
-                <UserButton appearance={{ elements: { userButtonPopoverCard: "bg-zinc-900" } }} />
-              </div>
-            </SignedIn>
-            <SignedOut>
-              <SignInButton>
-                <button className="w-full rounded-md bg-zinc-100 px-4 py-3 text-sm font-medium text-zinc-900 hover:bg-zinc-200">
-                  Entrar
-                </button>
-              </SignInButton>
-            </SignedOut>
-          </div>
+
+        {/* Sidebar desktop */}
+        <aside className="hidden md:flex md:flex-col border-r border-white/8 bg-[#040404]">
+          <SidebarContent />
         </aside>
+
         <div className="flex flex-col">
-          <header className="sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/70 backdrop-blur supports-[backdrop-filter]:bg-zinc-950/60 md:hidden">
-            <div className="flex items-center justify-between gap-4 px-6 py-4 md:px-8">
-              <div className="flex items-center gap-3 md:hidden">
+
+          {/* Header mobile */}
+          <header className="sticky top-0 z-10 border-b border-white/8 bg-[#040404]/80 backdrop-blur md:hidden">
+            <div className="flex items-center justify-between gap-4 px-6 py-4">
+              <div className="flex items-center gap-3">
                 <button
                   type="button"
                   onClick={() => setMobileOpen((open) => !open)}
                   aria-expanded={mobileOpen}
                   aria-controls="admin-mobile-nav"
-                  className="inline-flex items-center justify-center rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2 focus:ring-offset-zinc-950"
+                  className="inline-flex items-center justify-center rounded-md border border-white/10 bg-white/5 px-3 py-2 text-sm text-[#f1f1f1] hover:bg-white/10 focus:outline-none"
                 >
                   <span className="sr-only">{mobileOpen ? "Fechar menu" : "Abrir menu"}</span>
-                  <svg
-                    aria-hidden="true"
-                    className="h-5 w-5"
-                    viewBox="0 0 20 20"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                  >
-                    {mobileOpen ? (
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l8 8M6 14L14 6" />
-                    ) : (
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h14M3 10h14M3 14h14" />
-                    )}
-                  </svg>
+                  {mobileOpen
+                    ? <XMarkIcon className="h-5 w-5" />
+                    : <Bars3Icon className="h-5 w-5" />
+                  }
                 </button>
-                <Link href="/" className="font-semibold">domenyk.com</Link>
+                <Link href="/" className="text-sm font-semibold text-[#f1f1f1]">
+                  domenyk.com
+                </Link>
               </div>
-              <div className="flex-1" />
               <div className="flex items-center gap-4">
                 <SignedIn>
                   <UserButton appearance={{ elements: { userButtonPopoverCard: "bg-zinc-900" } }} />
                 </SignedIn>
                 <SignedOut>
                   <SignInButton>
-                    <button className="rounded-md bg-zinc-100 px-4 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200">
+                    <button className="rounded-md bg-[#E00070] px-4 py-2 text-xs font-medium text-white hover:opacity-80 transition">
                       Entrar
                     </button>
                   </SignInButton>
                 </SignedOut>
               </div>
             </div>
+
+            {/* Mobile nav dropdown */}
             {mobileOpen && (
               <div
                 id="admin-mobile-nav"
-                className="border-t border-b border-zinc-800 bg-zinc-900/95 px-6 py-4 md:hidden"
+                className="border-t border-white/8 bg-[#040404] px-4 py-4"
               >
-                <nav>
-                  <ul className="space-y-1 list-none p-0 m-0">
-                    {navItems.map((item) => {
-                      const isActive = pathname === item.href;
-                      return (
-                        <li key={item.href}>
-                          <Link
-                            href={item.href}
-                            onClick={() => setMobileOpen(false)}
-                            className={`block rounded-md px-3 py-2 text-sm font-medium transition-colors ${isActive
-                                ? "bg-zinc-800 text-zinc-100"
-                                : "text-zinc-400 hover:bg-zinc-800/60 hover:text-zinc-200"
-                              }`}
-                          >
-                            {item.label}
-                          </Link>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </nav>
+                <ul className="space-y-1 list-none p-0 m-0">
+                  {navItems.map((item) => {
+                    const isActive = pathname === item.href;
+                    const Icon = item.icon;
+                    return (
+                      <li key={item.href}>
+                        <Link
+                          href={item.href}
+                          onClick={() => setMobileOpen(false)}
+                          className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all ${
+                            isActive
+                              ? "bg-[#E00070]/10 text-[#f1f1f1] border border-[#E00070]/25"
+                              : "border border-transparent text-[#A8A095] hover:bg-white/5 hover:text-[#f1f1f1]"
+                          }`}
+                        >
+                          <Icon className={`h-4 w-4 shrink-0 ${isActive ? "text-[#E00070]" : "text-[#A8A095]"}`} />
+                          {item.label}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
             )}
           </header>
-          <main className="p-6 md:p-8 w-full max-w-screen-2xl mx-auto">{children}</main>
+
+          <main className="p-6 md:p-8 w-full max-w-screen-2xl mx-auto">
+            {children}
+          </main>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Modernize and unify the admin UI by introducing iconography, updated color tokens, and improved mobile behavior.
- Surface additional admin sections (`/admin/ideias`, `/admin/checklist`) in the primary navigation for easier access.
- Reduce duplication between desktop and mobile sidebars by extracting shared markup into a reusable block.

### Description

- Added Heroicons imports and updated `navItems` to include `icon` components for each route and new entries for `Banco de Ideias` and `Checklist`.
- Extracted the sidebar markup into a `SidebarContent` JSX function and reused it for the desktop sidebar while reworking the mobile nav to render the same items with icons and active-state styles.
- Replaced the mobile menu SVG with `Bars3Icon` and `XMarkIcon`, changed color tokens to specific hex values, and updated `SignedIn`/`SignedOut` button appearances and layout tweaks.
- Cleaned up layout classes and minor markup changes to `header`/`main` to match the refreshed visual style.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` and it completed successfully.
- Ran linting with `npm run lint` and no lint errors were reported.
- Performed a production build with `next build` which succeeded without build-time errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2f157ee88328bd41b0e825513ebd)