### PR TITLE
Admin dashboard: surface total/visible posts and comments, adjust recent list size

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -25,8 +25,11 @@ export default async function AdminDashboard() {
 
   const db = await getMongoDb();
   const postsCollection = db.collection("posts");
+  const commentsCollection = db.collection("comments");
+  const authCommentsCollection = db.collection("auth-comments");
 
-  const [count, viewsAgg, latest] = await Promise.all([
+  const [totalCount, visibleCount, viewsAgg, totalComments, latest] = await Promise.all([
+    postsCollection.countDocuments({}),
     postsCollection.countDocuments({ hidden: { $ne: true } }),
     postsCollection
       .aggregate<{ totalViews: number }>([
@@ -35,6 +38,10 @@ export default async function AdminDashboard() {
       ])
       .toArray()
       .then((arr) => arr[0]?.totalViews ?? 0),
+    Promise.all([
+      commentsCollection.countDocuments({ parentId: null }),
+      authCommentsCollection.countDocuments({ parentId: null }),
+    ]).then(([a, b]) => a + b),
     postsCollection
       .find(
         {},
@@ -53,7 +60,7 @@ export default async function AdminDashboard() {
         }
       )
       .sort({ date: -1 })
-      .limit(6)
+      .limit(3)
       .toArray() as unknown as Promise<PostRow[]>,
   ]);
 
@@ -92,8 +99,10 @@ export default async function AdminDashboard() {
 
       {/* Stats */}
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard label="Posts publicados" value={count} />
         <StatCard label="Views totais" value={totalViews.toLocaleString("pt-BR")} />
+        <StatCard label="Posts visíveis" value={visibleCount} />
+        <StatCard label="Posts publicados" value={totalCount} />
+        <StatCard label="Comentários totais" value={totalComments} />
       </section>
 
       {/* Recent posts */}


### PR DESCRIPTION
### Motivation

- Provide more accurate dashboard metrics by splitting total posts and visible posts and adding a total comments metric.
- Include comment sources from both `comments` and `auth-comments` collections in the total comments count.
- Reduce the number of recent posts shown in the dashboard to improve layout density.

### Description

- Added references to the `comments` and `auth-comments` collections and aggregate their root comment counts into `totalComments` using `countDocuments` on `parentId: null` across both collections.
- Split post counts into `totalCount` (all posts) and `visibleCount` (posts where `hidden` is not true) and kept the existing total views aggregation as `viewsAgg`.
- Updated the `Promise.all` to return `[totalCount, visibleCount, viewsAgg, totalComments, latest]` and adjusted variable usage accordingly.
- Changed the recent posts query `limit` from `6` to `3` and updated the dashboard `StatCard`s to show `Views totais`, `Posts visíveis`, `Posts publicados`, and `Comentários totais` in that order.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac367edc4483289912b24be17631f0)