### PR TITLE
Redesign admin dashboard UI and add per-post expandable config in RecentPostsClient

### DIFF
--- a/src/app/admin/RecentPostsClient.tsx
+++ b/src/app/admin/RecentPostsClient.tsx
@@ -32,12 +32,13 @@ function CheckboxBtn({ checked, onChange, label }: { checked: boolean; onChange:
       type="button"
       aria-pressed={checked}
       onClick={() => onChange(!checked)}
-      className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-xs ${checked
-        ? "border-zinc-500 bg-zinc-100 text-zinc-900"
-        : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"
-        }`}
+      className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs transition-colors ${
+        checked
+          ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]"
+          : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"
+      }`}
     >
-      <span className={`inline-block h-3 w-3 rounded-sm ${checked ? "bg-zinc-900" : "bg-transparent border border-zinc-600"}`} />
+      <span className={`inline-block h-3 w-3 rounded-sm border transition-colors ${checked ? "bg-[#E00070] border-[#E00070]" : "bg-transparent border-white/20"}`} />
       {label}
     </button>
   );
@@ -212,6 +213,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
   const [modalMode, setModalMode] = useState<"all" | "post">("all");
   const [modalOpen, setModalOpen] = useState(false);
   const [users, setUsers] = useState<Array<{ id: string; name: string }>>([]);
+  const [expandedConfig, setExpandedConfig] = useState<Record<string, boolean>>({});
 
   const selectedIds = useMemo(() => Object.keys(selected).filter((k) => selected[k]), [selected]);
   const allSelected = posts.length > 0 && selectedIds.length === posts.length;
@@ -236,7 +238,7 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
       const offset = reset ? 0 : posts.length;
       const params = new URLSearchParams({
         offset: String(offset),
-        limit: "5",
+        limit: "3",
         sort: sortKey,
         order: sortOrder,
       });
@@ -341,57 +343,42 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
     }
   };
 
-  const headerCells = [
-    { key: "select", label: "", className: "md:w-12" },
-    { key: "title", label: "Título" },
-    { key: "subtitle", label: "Subtítulo" },
-    { key: "id", label: "ID" },
-    { key: "date", label: "Data" },
-    { key: "views", label: "Views", align: "right" as const },
-    { key: "comments", label: "Comentários", align: "right" as const },
-    { key: "tags", label: "Tags" },
-    { key: "categories", label: "Categorias" },
-    { key: "coAuthor", label: "Co-autor" },
-    { key: "paragraphs", label: "Parágrafos", align: "right" as const },
-    { key: "pinned", label: "Fixado", align: "right" as const },
-    { key: "visibility", label: "Visibilidade", align: "right" as const },
-  ];
 
-  const cellBase = "md:table-cell md:border-t md:border-zinc-800/90 md:px-4 md:py-2.5";
-  const headerCellBase = "md:table-cell md:px-4 md:py-3";
 
   return (
     <>
       <div className="space-y-4">
-        <div className="rounded-lg border border-zinc-700/80 bg-zinc-800/50 p-3 shadow-sm">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-sm text-zinc-300">{selectedIds.length} selecionado(s)</div>
+        <div className="border border-white/8 rounded-lg bg-[#040404] px-4 py-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-xs text-[#A8A095]">
+              {selectedIds.length} selecionado(s)
+            </div>
             <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
               <button
                 onClick={handleDownload}
-                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
-                title={selectedIds.length > 0 ? `Baixar ${selectedIds.length} post(s) selecionado(s)` : "Baixar todos os posts"}
+                className="inline-flex w-full items-center justify-center rounded-md border border-white/10 px-3 py-1.5 text-xs text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1] disabled:opacity-40 sm:w-auto transition-colors"
+                title={selectedIds.length > 0 ? `Baixar ${selectedIds.length} post(s)` : "Baixar todos os posts"}
               >
                 {selectedIds.length > 0 ? `⬇ Baixar (${selectedIds.length})` : "⬇ Baixar todos"}
               </button>
               <button
                 onClick={() => bulkAction("visibility", { hidden: false })}
                 disabled={bulkLoading || selectedIds.length === 0}
-                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-100 px-3 py-2 text-xs font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60 sm:w-auto"
+                className="inline-flex w-full items-center justify-center rounded-md bg-[#E00070] px-3 py-1.5 text-xs font-medium text-white hover:opacity-80 disabled:opacity-30 sm:w-auto transition-opacity"
               >
                 Tornar visível
               </button>
               <button
                 onClick={() => bulkAction("visibility", { hidden: true })}
                 disabled={bulkLoading || selectedIds.length === 0}
-                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
+                className="inline-flex w-full items-center justify-center rounded-md border border-white/10 px-3 py-1.5 text-xs text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1] disabled:opacity-40 sm:w-auto transition-colors"
               >
                 Ocultar
               </button>
               <button
                 onClick={() => bulkAction("delete")}
                 disabled={bulkLoading || selectedIds.length === 0}
-                className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-red-300 hover:bg-zinc-800 disabled:opacity-60 sm:w-auto"
+                className="inline-flex w-full items-center justify-center rounded-md border border-white/10 px-3 py-1.5 text-xs text-red-400 hover:border-red-400/30 hover:bg-red-400/5 disabled:opacity-40 sm:w-auto transition-colors"
               >
                 Excluir
               </button>
@@ -399,8 +386,8 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
           </div>
         </div>
 
-        <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/30 p-3">
-          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-300">
+        <div className="border border-white/8 rounded-lg bg-[#040404] px-4 py-3">
+          <div className="flex flex-wrap items-center gap-3 text-xs">
             <CheckboxBtn
               checked={allSelected}
               onChange={(next) => {
@@ -410,233 +397,232 @@ export default function RecentPostsClient({ initial }: { initial: PostRow[] }) {
               }}
               label="selecionar todos"
             />
-            <span className="text-zinc-500 hidden sm:inline">|</span>
-            <span className="text-zinc-400">order:</span>
+            <span className="text-white/20 hidden sm:inline">|</span>
+            <span className="text-[#A8A095]">order:</span>
             <button
               onClick={() => toggleSort("date")}
-              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "date" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "date" ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]" : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"}`}
             >
               data
             </button>
             <button
               onClick={() => toggleSort("views")}
-              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "views" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "views" ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]" : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"}`}
             >
               views
             </button>
             <button
               onClick={() => toggleSort("status")}
-              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "status" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+              className={`rounded-md border px-3 py-1.5 transition-colors ${sortKey === "status" ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]" : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"}`}
             >
               status
             </button>
             <div className="ml-1 flex items-center gap-1">
               <button
                 onClick={() => setSortOrder("asc")}
-                className={`flex h-7 w-7 items-center justify-center rounded-md border transition-colors ${sortOrder === "asc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+                className={`flex h-7 w-7 items-center justify-center rounded-md border transition-colors ${sortOrder === "asc" ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]" : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"}`}
                 title="Crescente"
               >
                 ↑
               </button>
               <button
                 onClick={() => setSortOrder("desc")}
-                className={`flex h-7 w-7 items-center justify-center rounded-md border transition-colors ${sortOrder === "desc" ? "border-zinc-500 bg-zinc-100 text-zinc-900" : "border-zinc-700 bg-zinc-900 text-zinc-200 hover:bg-zinc-800"}`}
+                className={`flex h-7 w-7 items-center justify-center rounded-md border transition-colors ${sortOrder === "desc" ? "border-[#E00070]/40 bg-[#E00070]/10 text-[#f1f1f1]" : "border-white/10 text-[#A8A095] hover:border-white/20 hover:text-[#f1f1f1]"}`}
                 title="Decrescente"
               >
                 ↓
               </button>
             </div>
-            <span className="mx-2 hidden h-4 w-px bg-zinc-800 sm:block" />
+            <span className="mx-2 hidden h-4 w-px bg-white/8 sm:block" />
             <button
               onClick={() => {
                 setModalMode("all");
                 setModalPostId(null);
                 setModalOpen(true);
               }}
-              className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-zinc-200 transition-colors hover:bg-zinc-800 sm:w-auto"
+              className="w-full rounded-md border border-white/10 px-3 py-1.5 text-[#A8A095] transition-colors hover:border-white/20 hover:text-[#f1f1f1] sm:w-auto"
             >
               ver todos os comentários
             </button>
           </div>
         </div>
 
-        <div className="space-y-4 text-sm md:table md:w-full md:border-separate md:space-y-0 md:[border-spacing:0]">
-          <div className="hidden md:table-header-group bg-zinc-900/70 text-zinc-400 backdrop-blur">
-            <div className="md:table-row">
-              {headerCells.map((cell) => (
-                <div
-                  key={cell.key}
-                  className={`${headerCellBase} font-medium ${cell.className ?? ""} ${cell.align === "right" ? "text-right" : ""}`}
-                >
-                  {cell.label}
-                </div>
-              ))}
-            </div>
+        <div className="text-sm border border-white/8 rounded-lg overflow-hidden">
+          <div className="hidden md:grid md:grid-cols-[2fr_1fr_80px_120px_80px_80px_80px] border-b border-white/6 px-4 py-2">
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095]">Título</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095]">Data</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095] text-right">Views</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095] text-right">Comentários</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095] text-right">Fixado</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095] text-right">Visível</div>
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#A8A095] text-right"></div>
           </div>
-          <div className="space-y-4 md:table-row-group md:space-y-0">
+          <div className="divide-y divide-white/6">
             {posts.map((p) => (
               <div
                 key={p.postId}
-                className="space-y-4 rounded-xl border border-zinc-800/90 bg-zinc-900/40 p-4 transition-all hover:border-zinc-700 md:table-row md:space-y-0 md:rounded-none md:border-0 md:bg-transparent md:p-0 md:hover:bg-zinc-900/40"
+                className="group flex flex-col gap-3 px-4 py-3 transition-colors hover:bg-white/2 md:grid md:grid-cols-[2fr_1fr_80px_120px_80px_80px_80px] md:items-center md:gap-0"
               >
-                <div className={`${cellBase} md:w-12`}>
-                  <div className="flex items-center justify-between md:block">
-                    <span className="text-xs font-medium uppercase text-zinc-500 md:hidden">Seleção</span>
-                    <CheckboxBtn
-                      checked={!!selected[p.postId]}
-                      onChange={(next) => setSelected((s) => ({ ...s, [p.postId]: next }))}
-                    />
-                  </div>
-                </div>
-                <div className={`${cellBase} md:max-w-[320px] md:align-top`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Título</div>
+                <div className="flex items-center gap-3 min-w-0">
+                  <CheckboxBtn
+                    checked={!!selected[p.postId]}
+                    onChange={(next) => setSelected((s) => ({ ...s, [p.postId]: next }))}
+                  />
                   <Link
                     href={`/posts/${p.postId}`}
-                    className="block text-sm font-medium text-zinc-100 hover:underline md:max-w-[320px] md:truncate"
+                    className="truncate text-sm font-medium text-[#f1f1f1] hover:text-[#E00070] transition-colors"
                   >
                     {p.title}
                   </Link>
                 </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Subtítulo</div>
-                  <SubtitleEditor
-                    value={p.subtitle ?? null}
-                    onSave={async (next) => {
-                      await updateMeta(p.postId, { subtitle: next });
-                      setPosts((rows) =>
-                        rows.map((r) => (r.postId === p.postId ? { ...r, subtitle: next ?? null } : r))
-                      );
-                    }}
-                  />
+                <div className="text-xs text-[#A8A095] md:pl-2">
+                  {p.date ?? "-"}
                 </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">ID</div>
-                  <div className="text-sm text-zinc-400 break-all">{p.postId}</div>
-                </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Data</div>
-                  <div className="text-sm text-zinc-400">{p.date ?? "-"}</div>
-                </div>
-                <div className={`${cellBase} md:text-right`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Views</div>
-                  <div className="text-sm">{p.views ?? 0}</div>
+                <div className="text-xs text-[#f1f1f1] text-right tabular-nums">
+                  {p.views ?? 0}
                   <ScrollHeatmap postId={p.postId} />
                 </div>
-                <div className={`${cellBase} md:text-right`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Comentários</div>
+                <div className="text-right">
                   <button
                     onClick={() => {
                       setModalMode("post");
                       setModalPostId(p.postId);
                       setModalOpen(true);
                     }}
-                    className="inline-flex w-full items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 hover:bg-zinc-800 md:w-auto"
-                    title="Visualizar comentários"
+                    className="text-xs text-[#A8A095] hover:text-[#f1f1f1] transition-colors"
                   >
                     {p.commentCount ?? 0} comentários
                   </button>
                 </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Tags</div>
-                  <TagListEditor
-                    values={p.tags ?? []}
-                    label="tags"
-                    saving={false}
-                    onSave={async (next) => {
-                      await updateMeta(p.postId, { tags: next });
-                      setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, tags: next } : r)));
-                    }}
-                  />
+                <div className="flex justify-end">
+                  <PinToggle postId={p.postId} pinnedOrder={p.pinnedOrder} />
                 </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Categorias</div>
-                  <TagListEditor
-                    values={p.categories ?? []}
-                    label="categorias"
-                    saving={false}
-                    onSave={async (next) => {
-                      await updateMeta(p.postId, { categories: next });
-                      setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, categories: next } : r)));
-                    }}
-                  />
+                <div className="flex justify-end">
+                  <VisibilityToggle postId={p.postId} hidden={p.hidden} />
                 </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Co-autor</div>
-                  <select
-                    className="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 md:min-w-[160px] md:w-auto"
-                    value={p.coAuthorUserId ?? ""}
-                    onChange={async (e) => {
-                      const next = e.target.value;
-                      await updateMeta(p.postId, { coAuthorUserId: next || null });
-                      setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, coAuthorUserId: next || null } : r)));
-                    }}
+                <div className="flex justify-end">
+                  <button
+                    onClick={() =>
+                      setExpandedConfig((prev) => ({
+                        ...prev,
+                        [p.postId]: !prev[p.postId],
+                      }))
+                    }
+                    className={`text-xs transition-colors ${
+                      expandedConfig[p.postId]
+                        ? "text-[#E00070]"
+                        : "text-[#A8A095] hover:text-[#f1f1f1]"
+                    }`}
                   >
-                    <option value="">Nenhum</option>
-                    {users.map((u) => (
-                      <option key={u.id} value={u.id}>
-                        {u.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className={`${cellBase}`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Parágrafos</div>
-                  <div className="mt-2 md:mt-0">
-                    <ParagraphCommentsToggle
-                      postId={p.postId}
-                      enabled={p.paragraphCommentsEnabled !== false}
-                      onToggle={(next) =>
-                        setPosts((rows) =>
-                          rows.map((r) =>
-                            r.postId === p.postId
-                              ? { ...r, paragraphCommentsEnabled: next }
-                              : r
-                          )
-                        )
-                      }
-                    />
-                  </div>
-                </div>
-                <div className={`${cellBase} md:text-right`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">
-                    Fixado
-                  </div>
-                  <div className="mt-2 md:mt-0">
-                    <PinToggle postId={p.postId} pinnedOrder={p.pinnedOrder} />
-                  </div>
-                </div>
-                <div className={`${cellBase} md:text-right`}>
-                  <div className="text-xs font-medium uppercase text-zinc-500 md:hidden">Visibilidade</div>
-                  <div className="mt-2 md:mt-0">
-                    <VisibilityToggle postId={p.postId} hidden={p.hidden} />
-                  </div>
+                    {expandedConfig[p.postId] ? "fechar" : "config"}
+                  </button>
                 </div>
               </div>
             ))}
+            {posts.map((p) =>
+              expandedConfig[p.postId] ? (
+                <div
+                  key={`config-${p.postId}`}
+                  className="border-t border-white/6 bg-white/2 px-4 py-4"
+                >
+                  <div className="md:py-4">
+                    <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Subtítulo</span>
+                        <SubtitleEditor
+                          value={p.subtitle ?? null}
+                          onSave={async (next) => {
+                            await updateMeta(p.postId, { subtitle: next });
+                            setPosts((rows) =>
+                              rows.map((r) => (r.postId === p.postId ? { ...r, subtitle: next ?? null } : r))
+                            );
+                          }}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">ID</span>
+                        <span className="text-xs text-zinc-300 break-all font-mono">{p.postId}</span>
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Tags</span>
+                        <TagListEditor
+                          values={p.tags ?? []}
+                          label="tags"
+                          saving={false}
+                          onSave={async (next) => {
+                            await updateMeta(p.postId, { tags: next });
+                            setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, tags: next } : r)));
+                          }}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Categorias</span>
+                        <TagListEditor
+                          values={p.categories ?? []}
+                          label="categorias"
+                          saving={false}
+                          onSave={async (next) => {
+                            await updateMeta(p.postId, { categories: next });
+                            setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, categories: next } : r)));
+                          }}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Co-autor</span>
+                        <select
+                          className="rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-200 md:min-w-[160px]"
+                          value={p.coAuthorUserId ?? ""}
+                          onChange={async (e) => {
+                            const next = e.target.value;
+                            await updateMeta(p.postId, { coAuthorUserId: next || null });
+                            setPosts((rows) => rows.map((r) => (r.postId === p.postId ? { ...r, coAuthorUserId: next || null } : r)));
+                          }}
+                        >
+                          <option value="">Nenhum</option>
+                          {users.map((u) => (
+                            <option key={u.id} value={u.id}>{u.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="flex flex-col gap-1.5">
+                        <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-500">Parágrafos</span>
+                        <ParagraphCommentsToggle
+                          postId={p.postId}
+                          enabled={p.paragraphCommentsEnabled !== false}
+                          onToggle={(next) =>
+                            setPosts((rows) =>
+                              rows.map((r) =>
+                                r.postId === p.postId ? { ...r, paragraphCommentsEnabled: next } : r
+                              )
+                            )
+                          }
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : null
+            )}
             {posts.length === 0 && !loading && (
               <div className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-6 text-center text-zinc-400 md:table-row md:border-0 md:bg-transparent md:p-0">
-                <div className={`${cellBase} text-center md:py-8`}>
+                <div className="py-8 text-center">
                   Nenhum post encontrado.
                 </div>
               </div>
             )}
-            <div className="rounded-xl border border-zinc-800/90 bg-zinc-900/70 p-4 shadow-[0_12px_32px_-24px_rgba(0,0,0,0.9)] md:table-row md:rounded-none md:border-0 md:bg-transparent md:p-0 md:shadow-none">
-              <div className={`${cellBase}`}>
-                <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-                  {error && <span className="text-sm text-red-500 sm:mr-4">{error}</span>}
-                  {hasMore ? (
-                    <button
-                      onClick={() => onLoadMore(false)}
-                      disabled={loading}
-                      className="inline-flex items-center justify-center rounded-md bg-zinc-100 px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-200 disabled:opacity-60"
-                    >
-                      {loading ? "Carregando..." : "Mostrar mais"}
-                    </button>
-                  ) : (
-                    <span className="text-sm text-zinc-400">Todos os posts carregados</span>
-                  )}
-                </div>
-              </div>
+            <div className="border-t border-white/6 px-4 py-3 flex items-center justify-center">
+              {error && <span className="text-xs text-red-400 mr-4">{error}</span>}
+              {hasMore ? (
+                <button
+                  onClick={() => onLoadMore(false)}
+                  disabled={loading}
+                  className="text-xs text-[#A8A095] hover:text-[#f1f1f1] disabled:opacity-40 transition-colors"
+                >
+                  {loading ? "carregando..." : "mostrar mais"}
+                </button>
+              ) : (
+                <span className="text-xs text-[#A8A095]/50">todos os posts carregados</span>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -71,17 +71,17 @@ export default async function AdminDashboard() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="text-xl font-medium tracking-tight text-zinc-100">
+          <h1 className="text-xl font-semibold tracking-tight text-[#f1f1f1]">
             Dashboard
           </h1>
-          <p className="mt-1 text-sm text-zinc-500">
+          <p className="mt-1 text-sm text-[#A8A095]">
             Resumo do seu conteúdo e desempenho.
           </p>
         </div>
         <div className="flex gap-2">
           <Link
             href="/admin/editor"
-            className="inline-flex items-center gap-1.5 rounded-md bg-zinc-100 px-3.5 py-1.5 text-sm font-medium text-zinc-900 transition-colors hover:bg-white"
+            className="inline-flex items-center gap-1.5 rounded-md bg-[#E00070] px-3.5 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-80"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
               <path d="M8 3v10M3 8h10" />
@@ -90,7 +90,7 @@ export default async function AdminDashboard() {
           </Link>
           <Link
             href="/admin/analytics"
-            className="inline-flex items-center rounded-md border border-zinc-800 px-3.5 py-1.5 text-sm text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200"
+            className="inline-flex items-center rounded-md border border-white/10 px-3.5 py-1.5 text-sm text-[#A8A095] transition-colors hover:border-white/20 hover:text-[#f1f1f1]"
           >
             Analytics
           </Link>
@@ -98,8 +98,8 @@ export default async function AdminDashboard() {
       </div>
 
       {/* Stats */}
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard label="Views totais" value={totalViews.toLocaleString("pt-BR")} />
+      <section className="grid sm:grid-cols-2 lg:grid-cols-4 border border-white/8 rounded-lg overflow-hidden divide-x divide-white/8">
+        <StatCard label="Views totais" value={totalViews.toLocaleString("pt-BR")} accent />
         <StatCard label="Posts visíveis" value={visibleCount} />
         <StatCard label="Posts publicados" value={totalCount} />
         <StatCard label="Comentários totais" value={totalComments} />
@@ -107,26 +107,24 @@ export default async function AdminDashboard() {
 
       {/* Recent posts */}
       <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium text-zinc-400">Recentes</h2>
+        <div className="mb-3">
+          <h2 className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
+            Posts
+          </h2>
         </div>
-        <div className="overflow-hidden rounded-lg border border-zinc-800/60">
-          <div className="overflow-x-auto">
-            <RecentPostsClient initial={latest as any} />
-          </div>
-        </div>
+        <RecentPostsClient initial={latest as any} />
       </section>
     </div>
   );
 }
 
-function StatCard({ label, value }: { label: string; value: string | number }) {
+function StatCard({ label, value, accent }: { label: string; value: string | number; accent?: boolean }) {
   return (
-    <div className="rounded-lg border border-zinc-800/60 bg-zinc-900/40 px-5 py-4">
-      <div className="text-xs font-medium uppercase tracking-wider text-zinc-500">
+    <div className="bg-[#040404] px-5 py-5 flex flex-col gap-3">
+      <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
         {label}
       </div>
-      <div className="mt-2 text-2xl font-semibold tabular-nums tracking-tight text-zinc-100">
+      <div className={`text-3xl font-semibold tabular-nums tracking-tight ${accent ? "text-[#E00070]" : "text-[#f1f1f1]"}`}>
         {value}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Refresh the admin dashboard visual design and improve usability of the recent posts list by consolidating controls and making per-post settings easier to access.
- Surface important actions and metadata in a compact grid and provide an expandable config area for editing tags, subtitle, co-author and paragraph comment settings.

### Description
- Restyled the RecentPostsClient and admin dashboard components with new colors, spacing and button styles, including a redesigned header, stat cards and action buttons.
- Replaced the previous table layout with a responsive grid for posts and added `expandedConfig` state to toggle a per-post expandable configuration panel that contains `SubtitleEditor`, `TagListEditor`, co-author `select`, and `ParagraphCommentsToggle` controls.
- Updated `CheckboxBtn` visuals and added smooth `transition-colors` classes across interactive controls, and moved pin/visibility toggles into the new compact row layout while exposing a `config` button to toggle details.
- Changed the posts fetch `limit` from `5` to `3` and adjusted how the recent posts component is embedded in the admin page; added an `accent` prop to `StatCard` to support the new visual highlight.

### Testing
- Ran static type checks with `tsc --noEmit` which succeeded.
- Ran linting via `npm run lint` which completed with no errors.
- Executed the automated test suite via `npm test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac3c6e5af483289270090f1769847e)