### PR TITLE
Tweak layout and styling: narrow container, adjust spacing, and simplify post list UI

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -24,7 +24,7 @@ export function Layout({ home = false, children, hideHeaderControls = false }: L
   return (
     <div
       data-scroll-progress-root
-      className="max-w-2xl flex flex-col mx-auto px-5 mb-4"
+      className="max-w-xl flex flex-col mx-auto px-4 mb-4"
     >
       <ScrollProgressEffect />
       <header className="flex justify-between items-center py-1">

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -59,10 +59,10 @@ a {
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 ul {
-  @apply list-disc ml-10;
+  @apply list-none ml-10;
 }
 .ml-0 {
   @apply ml-0;

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -133,7 +133,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
   return (
     <section className="flex-1 gap-6">
       <div className="mb-5 flex flex-row flex-wrap items-center gap-2 sm:mb-6 sm:gap-3">
-        <h1 className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
+        <h1 className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
           Posts
           <span className="tabular-nums">({totalCount})</span>
         </h1>
@@ -216,7 +216,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
                 prefetch={false}
                 className="flex flex-col gap-2 text-left focus-visible:outline-none focus-visible:ring-0"
               >
-                <span className="text-lg font-semibold leading-snug text-[#f1f1f1] transition-colors group-hover:text-[#E00070]">
+                <span className="text-lg font-semibold leading-snug text-[#f1f1f1]">
                   {post.title}
                 </span>
                 <div className="flex items-center gap-3">
@@ -227,14 +227,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
                   <span className="text-xs text-[#A8A095] tabular-nums">
                     {post.views ?? 0} views
                   </span>
-                  {post.tags && post.tags.length > 0 && (
-                    <>
-                      <span aria-hidden className="text-[#A8A095]/40">·</span>
-                      <span className="text-[10px] font-bold uppercase tracking-wider text-[#A8A095]">
-                        {post.tags[0]}
-                      </span>
-                    </>
-                  )}
+                  {null}
                 </div>
               </Link>
               {isAdmin && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,7 +121,7 @@ export default async function HomePage({
   return (
     <Layout home>
       <Header home={true} />
-      <section className="text-xl flex flex-col gap-3 py-6 text-primary items-center text-center">
+      <section className="flex flex-col gap-1 py-2 items-center text-center">
         <p className="text-lg text-zinc-200">
           Dou minhas opiniões aqui
         </p>


### PR DESCRIPTION
### Motivation
- Narrow the main content container and reduce horizontal padding to tighten the overall layout.  
- Simplify global link and list styles for a cleaner, more consistent appearance.  
- Reduce visual noise in the post list by removing hover color and tag display and adjusting header sizing.

### Description
- Update `components/layout.tsx` to change the root container classes from `max-w-2xl px-5` to `max-w-xl px-4` to reduce width and padding.  
- Modify `src/app/global.css` to remove underline on `a:hover` and switch `ul` from `@apply list-disc` to `@apply list-none`, keeping existing scrollbar and image utility styles.  
- Adjust `src/app/home-client.tsx` to reduce the header label size from `text-[10px]` to `text-[9px]`, remove the `group-hover:text-[#E00070]` title hover color, and stop rendering post tags (replaced with `{null}`).  
- Change the home intro section in `src/app/page.tsx` to use reduced spacing and padding by replacing `text-xl flex flex-col gap-3 py-6 text-primary` with `flex flex-col gap-1 py-2`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac67d090508328abdefc537f1978af)