### PR TITLE
Adjust home header spacing and posts heading style

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -14,7 +14,7 @@ export function Header({ home }: HeaderProps) {
   
 
   return (
-    <header className="flex flex-col items-center gap-4 py-6">
+    <header className="flex flex-col items-center gap-4 pt-6 pb-2">
       {home ? (
         <>
           <Image

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -14,13 +14,13 @@ export function Header({ home }: HeaderProps) {
   
 
   return (
-    <header className="flex flex-col items-center gap-4 pt-6 pb-2">
+    <header className="flex flex-col items-center gap-4 pb-2">
       {home ? (
         <>
           <Image
             priority
             src="/images/profile.jpg"
-            className="rounded-full brightness-110 foto"
+            className="rounded-full brightness-125 foto"
             height={148}
             width={148}
             alt={name}
@@ -35,7 +35,7 @@ export function Header({ home }: HeaderProps) {
             <Image
               priority
               src="/images/profile.jpg"
-              className="rounded-full brightness-110 foto transition-opacity hover:opacity-80"
+              className="rounded-full brightness-125 foto transition-opacity hover:opacity-80"
               height={148}
               width={148}
               alt={name}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -133,9 +133,9 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
   return (
     <section className="flex-1 gap-6">
       <div className="mb-5 flex flex-row flex-wrap items-center gap-2 sm:mb-6 sm:gap-3">
-        <h1 className="flex items-center gap-2 text-[9px] font-bold uppercase tracking-[0.18em] text-[#A8A095]">
+        <h1 className="flex items-center gap-1 text-sm font-semibold text-[#f1f1f1]">
           Posts
-          <span className="tabular-nums">({totalCount})</span>
+          <span className="tabular-nums text-[#A8A095] font-normal">({totalCount})</span>
         </h1>
         <div className="w-auto">
           <SearchBar

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -133,9 +133,9 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
   return (
     <section className="flex-1 gap-6">
       <div className="mb-5 flex flex-row flex-wrap items-center gap-2 sm:mb-6 sm:gap-3">
-        <h1 className="flex items-center gap-1 text-sm font-semibold text-[#f1f1f1]">
+        <h1 className="flex items-center gap-1 text-sm font-semibold uppercase tracking-wide text-[#f1f1f1]">
           Posts
-          <span className="tabular-nums text-[#A8A095] font-normal">({totalCount})</span>
+          <span className="tabular-nums text-[#f1f1f1] font-normal">({totalCount})</span>
         </h1>
         <div className="w-auto">
           <SearchBar
@@ -216,7 +216,7 @@ export default function HomeClient({ posts, isAdmin, page, hasNext, total }: Hom
                 prefetch={false}
                 className="flex flex-col gap-2 text-left focus-visible:outline-none focus-visible:ring-0"
               >
-                <span className="text-lg font-semibold leading-snug text-[#f1f1f1]">
+                <span className="text-lg font-normal leading-snug text-[#f1f1f1]">
                   {post.title}
                 </span>
                 <div className="flex items-center gap-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -121,7 +121,7 @@ export default async function HomePage({
   return (
     <Layout home>
       <Header home={true} />
-      <section className="flex flex-col gap-1 py-2 items-center text-center">
+      <section className="flex flex-col gap-1 pb-4 items-center text-center">
         <p className="text-lg text-zinc-200">
           Dou minhas opiniões aqui
         </p>


### PR DESCRIPTION
### Motivation
- Reduce vertical gaps around the home header/profile and make the "Posts (N)" label match the requested visual style (normal semibold white text with a gray counter).

### Description
- Update `src/app/home-client.tsx` to change the `h1` for posts to `text-sm font-semibold text-[#f1f1f1]` and the counter `span` to `text-[#A8A095] font-normal` with a smaller gap. 
- Update `src/app/page.tsx` to change the intro section from `py-2` to `pb-4` to reduce top spacing above the bio. 
- Update `components/header.tsx` to change the header padding from `py-6` to `pt-6 pb-2` to bring the header closer to the following text.

### Testing
- Ran `npm run build`, which failed due to missing environment variables `MONGODB_URI` and `MONGODB_DB` in this environment. 
- Launched `npm run dev`, the dev server started and compiled, and a Playwright screenshot of the home page was captured, but the page returned HTTP 500 locally because the same environment variables are not set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8a6e0bb08328b9892cbd6c494f96)