### PR TITLE
Integrate @chenglou/pretext for adaptive post content font sizing

### DIFF
--- a/components/usePostContentFontSize.ts
+++ b/components/usePostContentFontSize.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState, type RefObject } from "react";
+import { prepare, layout } from "@chenglou/pretext";
+
+export function usePostContentFontSize(
+  paragraphTexts: string[],
+  containerRef: RefObject<HTMLElement | null>,
+  options: {
+    minSize?: number;
+    maxSize?: number;
+    fontFamily?: string;
+    lineHeightRatio?: number;
+    maxLinesPerParagraph?: number;
+  } = {}
+): number {
+  const {
+    minSize = 14,
+    maxSize = 18,
+    fontFamily = "PolySans",
+    lineHeightRatio = 1.625,
+    maxLinesPerParagraph = 6,
+  } = options;
+
+  const [fontSize, setFontSize] = useState(maxSize);
+
+  useEffect(() => {
+    let cancelled = false;
+    const texts = paragraphTexts.filter(Boolean);
+    if (!texts.length) return;
+
+    const measure = () => {
+      const width = containerRef.current?.clientWidth ?? 0;
+      if (!width || cancelled) return;
+
+      let lo = minSize;
+      let hi = maxSize;
+      let optimal = minSize;
+
+      while (lo <= hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        const font = `${mid}px ${fontFamily}`;
+        const lh = mid * lineHeightRatio;
+
+        let totalLines = 0;
+        for (const text of texts) {
+          const prepared = prepare(text, font);
+          const { lineCount } = layout(prepared, width, lh);
+          totalLines += lineCount;
+        }
+        const avg = totalLines / texts.length;
+
+        if (avg <= maxLinesPerParagraph) {
+          optimal = mid;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+
+      if (!cancelled) setFontSize(optimal);
+    };
+
+    document.fonts.ready.then(measure);
+
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => {
+      cancelled = true;
+      ro.disconnect();
+    };
+  }, [paragraphTexts, minSize, maxSize, fontFamily, lineHeightRatio, maxLinesPerParagraph]);
+
+  return fontSize;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth0/nextjs-auth0": "^4.12.0",
+        "@chenglou/pretext": "^0.0.4",
         "@clerk/nextjs": "6.34.5",
         "@heroicons/react": "^2.2.0",
         "@lexical/react": "^0.38.2",
@@ -103,6 +104,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.4.tgz",
+      "integrity": "sha512-FnPAFMid1/p1j2V2gRPUVBarGUIb2PhkkC9YNnTOfPtTDgHKh8siO8PP9pCxpFfYlcodWPJpE1UbSHGQqt8pQQ==",
+      "license": "MIT"
     },
     "node_modules/@clerk/backend": {
       "version": "2.20.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^4.12.0",
+    "@chenglou/pretext": "^0.0.4",
     "@clerk/nextjs": "6.34.5",
     "@heroicons/react": "^2.2.0",
     "@lexical/react": "^0.38.2",

--- a/src/app/posts/[id]/post-content-client.tsx
+++ b/src/app/posts/[id]/post-content-client.tsx
@@ -16,7 +16,7 @@ import PostContentShell, {
 } from "./post-content-interactive";
 import SectionAttentionTracker from "@components/analytics/SectionAttentionTracker";
 import HeatmapProgressBar from "@components/HeatmapProgressBar";
-import { useContext, useRef, type HTMLAttributes, type RefObject } from "react";
+import { useContext, useMemo, useRef, type HTMLAttributes, type RefObject } from "react";
 import { useCommentsSummary } from "@components/paragraph-comments/useCommentsSummary";
 import ImageParagraph from "@components/ImageParagraph";
 import { useHighlights } from "@components/paragraph-comments/useHighlights";
@@ -274,6 +274,13 @@ export default function PostContentClient({
   const openCommentsFnsRef = useRef<Map<string, () => Promise<void>>>(new Map());
   let paragraphIndex = 0;
 
+  const paragraphTexts = useMemo(() => {
+    const matches = htmlContent.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi);
+    return Array.from(matches)
+      .map((m) => m[1].replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim())
+      .filter(Boolean);
+  }, [htmlContent]);
+
   type ReplaceReturn = ReturnType<NonNullable<HTMLReactParserOptions["replace"]>>;
 
   const parserOptions: HTMLReactParserOptions = {};
@@ -391,6 +398,7 @@ export default function PostContentClient({
       audioUrl={audioUrl}
       isEditing={isEditing}
       contentRef={contentRef}
+      paragraphTexts={paragraphTexts}
     >
       <SectionAttentionTracker postId={postId} />
       <HeatmapProgressBar postId={postId} />

--- a/src/app/posts/[id]/post-content-interactive.tsx
+++ b/src/app/posts/[id]/post-content-interactive.tsx
@@ -23,6 +23,7 @@ import { useRealReadingTime } from "@components/useRealReadingTime";
 import AudioPlayer from "@components/AudioPlayer";
 import PostMinimap from "@components/PostMinimap";
 import { EyeIcon, ClockIcon } from "@heroicons/react/24/solid";
+import { usePostContentFontSize } from "@components/usePostContentFontSize";
 
 export type ParagraphCommentWidgetProps = {
   postId: string;
@@ -270,6 +271,7 @@ type PostContentShellProps = {
   secondaryHeaderSlot?: ReactNode;
   isEditing?: boolean;
   contentRef?: RefObject<HTMLDivElement | null>;
+  paragraphTexts?: string[];
 };
 
 export default function PostContentShell({
@@ -284,10 +286,17 @@ export default function PostContentShell({
   secondaryHeaderSlot,
   isEditing = false,
   contentRef,
+  paragraphTexts,
 }: PostContentShellProps) {
   const [views, setViews] = useState(initialViews);
   const displayReadingTime = useRealReadingTime(postId, readingTime);
   const [isMobile, setIsMobile] = useState(false);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const adaptiveFontSize = usePostContentFontSize(
+    paragraphTexts ?? [],
+    measureRef,
+    { minSize: 14, maxSize: 18 }
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -382,10 +391,14 @@ export default function PostContentShell({
 
           <div
             data-post-content
-            className="flex flex-col gap-4 lg:text-lg sm:text-sm max-sm:text-xs"
+            className="flex flex-col gap-4"
+            style={paragraphTexts?.length ? { fontSize: adaptiveFontSize } : undefined}
             contentEditable={isEditing || undefined}
             suppressContentEditableWarning
-            ref={contentRef}
+            ref={(el) => {
+              measureRef.current = el;
+              if (contentRef) contentRef.current = el;
+            }}
           >
             {children}
           </div>


### PR DESCRIPTION
Replaces the hardcoded lg:text-lg sm:text-sm max-sm:text-xs breakpoints
with a pretext-powered binary search that finds the largest font size
where paragraphs average ≤ 6 lines, improving readability on mobile.

- Add usePostContentFontSize hook using prepare()/layout() from pretext
- Extract paragraph plain texts from htmlContent in PostContentClient
- PostContentShell applies adaptive fontSize via inline style when texts are available
- Uses document.fonts.ready so PolySans is measured (not a fallback font)
- ResizeObserver reruns on orientation/viewport changes

https://claude.ai/code/session_01KPuSTQ3dJS6Fdn6UZ9Nzaj